### PR TITLE
fix: footer github icon size

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -11,7 +11,7 @@ const socials = [
   {
     name: "GitHub",
     url: "https://github.com/TechForPalestine/",
-    icon: "bi:github",
+    icon: "mdi:github",
   },
   {
     name: "Discord",


### PR DESCRIPTION
Fixing a visual inconsistency with footer github icon:

Before (using bi)
<img width="188" alt="Screenshot 2024-01-21 at 12 26 44 PM" src="https://github.com/TechForPalestine/website/assets/19797958/ce4f50be-68cb-45f8-a1e5-b73010ed7941">

After (using mdi)
<img width="191" alt="Screenshot 2024-01-21 at 12 26 23 PM" src="https://github.com/TechForPalestine/website/assets/19797958/06cdeeb6-9eac-4cd2-b25d-4e2dcc0ae12e">
