### PR TITLE
fix: use rss icon for updates

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -21,7 +21,7 @@ const socials = [
   {
     name: "Blog",
     url: "https://updates.techforpalestine.org",
-    icon: "mdi:blog",
+    icon: "mdi:rss",
   },
 ];
 ---


### PR DESCRIPTION
Fixes https://github.com/TechForPalestine/website/issues/21

Uses this rss icon for updates:
![image](https://github.com/TechForPalestine/website/assets/19797958/45d1ff8a-1b76-4aa5-8f3e-aa5588614a62)
