### PR TITLE
Update Navigation styles to support mobile screens

### DIFF
--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -30,7 +30,7 @@ const navigation = [
 
 <header class="flex flex-col sticky w-full top-0 z-50 bg-white border-b">
   <div class="relative">
-    <nav class="flex justify-center items-center w-full px-4 gap-4 py-2">
+    <nav class="flex flex-col md:flex-row lg:flex-row justify-center items-center w-full px-4 gap-4 py-2">
       <div>
         <a href="/" class="text-red-600"
           ><svg


### PR DESCRIPTION
* Set the default flex-direction to column and used the overrides to set it to row for larger screens. This allows the navigation to fit on mobile screens without pushing the page over.

**Before**

![broken-nav](https://github.com/TechForPalestine/website/assets/5439242/069238c8-542c-4d50-9d00-81b86a183b7a)

**After**

![fixed-nav](https://github.com/TechForPalestine/website/assets/5439242/bb33bf4d-d305-4b71-9570-f805dbc0a941)
