### PR TITLE
Fix a broken link.

### DIFF
--- a/src/pages/help/hire.astro
+++ b/src/pages/help/hire.astro
@@ -57,7 +57,7 @@ const resourceSections = [
       },
       {
         name: 'Rising from Ashes',
-        url: 'https://ps.bees.to/',
+        url: 'https://bees.to/hire-ps/',
         logo: '/bees-logo-horizontal.webp',
         description: `Leveraging partnerships with Bees, Flow Accelerator, and Gaza Sky Geeks, this platform is purpose built to connect global companies with remote workers on the ground in Palestine.`,
       },


### PR DESCRIPTION
The 'Rising From Ashes' site's landing page is now "bees.to/hire-ps/".