### PR TITLE
prerender popular pages

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -20,6 +20,11 @@ const {
     <meta name="viewport" content="width=device-width" />
     <link rel="icon" type="image/svg+xml" href="/favicon.png" />
     <link rel="me" href="https://infosec.exchange/@tech4palestine" />
+    <script type="speculationrules">
+    {
+        "prerender": [{"urls": ["/", "/about", "/incubator", "/project", "/tools", "/help/hire"]}]
+    }
+    </script>
     <meta name="generator" content={Astro.generator} />
     <title>{title}</title>
     <meta

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -1,0 +1,9 @@
+import { defineMiddleware } from "astro:middleware";
+
+export const onRequest = defineMiddleware(async (context, next) => {
+  const response = await next();
+
+  response.headers.set("Cache-Control", "public, max-age=600");
+
+  return response;
+});


### PR DESCRIPTION
Enable instant page load for users using
https://developer.mozilla.org/en-US/docs/Web/API/Speculation_Rules_API
Also enabled cache control so it caches the page request for 10 minutes in the browser(or cdn if you are using one) and won't hit the server.
You can test it by navigating through header links.
The policy for caching and prerendering is adjustable.