### PR TITLE
fix header client only (SEO)

### DIFF
--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -26,7 +26,7 @@ const navigation = new Map([
 // TODO: MOVE BANNER TO LAYOUT
 ---
 
-<NavBar navigation={navigation} currentRoute={currentRoute} client:only="svelte">
+<NavBar navigation={navigation} currentRoute={currentRoute}>
   <TFPLogo slot="tfp-logo" />
   <Socials slot="socials" />
   <Icon name="solar:hamburger-menu-outline" class="h-8 w-8" slot="burger-icon" />


### PR DESCRIPTION
The client only tag hurts SEO.
Because the web scrappers sometimes don't load JS to read the content of your website. It is better to always not render client only unless it is necessary. I see the same issue in some other pages (e.g. `volunteer.astro`, `success.astro`)
It also causes unwanted snap sometimes in the header.