### PR TITLE
Add Visualizing Palestine to resources page

### DIFF
--- a/src/components/FAQAccordion.tsx
+++ b/src/components/FAQAccordion.tsx
@@ -19,7 +19,7 @@ export default function FAQAccordion({ question, answer }: FAQAccordionProps) {
             <AccordionSummary
                 expandIcon={<ExpandMoreIcon />}
                 aria-controls="faq-content"
-                id={`faq-${question}`}
+                id={`faq-${question.replaceAll(' ', '-')}`}
             >
                 <Typography>{question}</Typography>
             </AccordionSummary>

--- a/src/components/FAQAccordion.tsx
+++ b/src/components/FAQAccordion.tsx
@@ -24,7 +24,7 @@ export default function FAQAccordion({ question, answer }: FAQAccordionProps) {
                 <Typography>{question}</Typography>
             </AccordionSummary>
             <AccordionDetails>
-                <Typography>{answer}</Typography>
+                {answer}
             </AccordionDetails>
         </Accordion>
     );

--- a/src/components/FAQList.tsx
+++ b/src/components/FAQList.tsx
@@ -7,22 +7,52 @@ const faqs = [
         question: 'Can Tech for Palestine help our non-profit build an app or website?',
         answer: (
             <>
-                Our partner{' '}
-                <Link
-                    href="https://techtotherescue.org/"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                >
-                    Tech to the Rescue
-                </Link>{' '}
-                is the right place for that. They will partner you with a tech company, typically within 6 weeks, who will work with you to build what you need for free.{' '}
-                <Link
-                    href="https://techtotherescue.org/"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                >
-                    You can sign up for help here.
-                </Link>
+                <Typography>
+                    Our partner{' '}
+                    <Link
+                        href="https://techtotherescue.org/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        Tech to the Rescue
+                    </Link>{' '}
+                    is the right place for that. They will partner you with a tech company, typically within 6 weeks, who will work with you to build what you need for free.{' '}
+                    <Link
+                        href="https://techtotherescue.org/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        You can sign up for help here.
+                    </Link>
+                </Typography>
+            </>
+        )
+    },
+    {
+        question: 'Where can I get graphical resources about Palestine for my advocacy work?',
+        answer: (
+            <>
+                <Typography>
+                    <Link
+                        href="https://visualizingpalestine.org/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        Visualizing Palestine
+                    </Link>{' '}
+                    produces graphics which are freely available and are intended to be used by advocates and educators. Hundreds of{' '}
+                    <Link
+                        href="https://visualizingpalestine.org/visuals"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        high quality graphics
+                    </Link>{' '}
+                    are available and can be used on social media and in education resources for free and without advanced permission.
+                </Typography>
+                <Typography sx={{ mt: 4}}>
+                    Visualizing Palestine uses data and research to visually communicate Palestinian experiences to provoke narrative change. Their freely available digital and print visuals tell the story of Palestinians' dispossession, apartheid and genocide.
+                </Typography>
             </>
         )
     },


### PR DESCRIPTION
Adds a FAQ entry on the resources page for [Visualizing Palestine](https://visualizingpalestine.org/), after discussing with @pbiggar.

The `<Accordion>` component did not support multiple paragraphs, so I made a small adjustment there.

I also implemented a not-very-robust fix for spaces in the aria attributes which is in a separate commit if you don't want to use it.