### PR TITLE
Fix Cloudflare Pages deployment by updating package manager version

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "web",
   "type": "module",
   "version": "0.0.1",
-  "packageManager": "yarn@1.22.21",
+  "packageManager": "yarn@1.22.22",
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",


### PR DESCRIPTION
Updated packageManager field in package.json from yarn@1.22.21 to yarn@1.22.22 to match the yarn version in dependencies and resolve corepack version conflicts during Cloudflare Pages build process.

🤖 Generated with [Claude Code](https://claude.ai/code)