### PR TITLE
Reorganize navbar navigation order

### DIFF
--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -12,17 +12,16 @@ const toggle = () => {
 const currentRoute = Astro.url.pathname;
 
 const navigation = new Map([
+  ["Get Involved", "/get-involved"],
   ["About", "/about"],
   ["Incubator", "/incubator"],
   ["Projects", "/projects"],
+  ["Ideas", "/ideas"],
   ["Blog", "https://updates.techforpalestine.org"],
   ["Hire Palestinians", "/help/hire"],
   ["Media", "/media"],
-  ["Get Involved", "/get-involved"],
-  ["Donate", "/donate"],
   ["Tools", "/tools"],
   ["Resources", "/resources"],
-  ["Ideas", "/ideas"],
 ]);
 
 // TODO: MOVE BANNER TO LAYOUT


### PR DESCRIPTION
- Move 'Get Involved' to first position
- Move 'Ideas' next to 'Projects'
- Remove 'Donate' from navbar (still available elsewhere)

🤖 Generated with [Claude Code](https://claude.ai/code)