### PR TITLE
fix notion image expiration with cloudflare worker proxy

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,63 @@
+# Notion Image Proxy Deployment
+
+This project uses a Cloudflare Worker to proxy Notion images and prevent URL expiration.
+
+**Important**: The Cloudflare Worker is deployed separately from your website. The worker files in `cloudflare-worker/` are NOT part of your Cloudflare Pages auto-deployment.
+
+## Setup Instructions
+
+### 1. Deploy the Cloudflare Worker
+
+```bash
+# Install Wrangler CLI if you haven't already
+npm install -g wrangler
+
+# Login to Cloudflare
+wrangler login
+
+# Navigate to worker directory and deploy
+cd cloudflare-worker
+wrangler deploy
+```
+
+### 2. Configure Custom Domain (Recommended)
+
+1. In Cloudflare Dashboard → Workers & Pages → Your Worker
+2. Go to "Triggers" tab
+3. Add a custom domain (e.g., `notion-images.yourdomain.com`)
+
+### 3. Update Environment Variable
+
+Add the worker URL to your environment:
+
+```bash
+# .env (local development)
+NOTION_IMAGE_PROXY_URL=https://notion-images.yourdomain.com
+
+# In Cloudflare Pages environment variables
+NOTION_IMAGE_PROXY_URL=https://notion-images.yourdomain.com
+```
+
+### 4. Test the Setup
+
+1. Build and deploy your site
+2. Check that event images load correctly
+3. Verify images don't break after 1 hour
+
+## How It Works
+
+1. **Image Detection**: The `notionClient.ts` detects Notion-hosted images (`file.type === "file"`)
+2. **URL Proxying**: Converts expiring S3 URLs to stable proxy URLs
+3. **Caching**: Worker caches images at Cloudflare edge for 24 hours
+4. **Fallback**: If proxy fails, falls back to original URL
+
+## URL Format
+
+- **Original**: `https://s3.us-west-2.amazonaws.com/...?expires=...`
+- **Proxied**: `https://notion-images.yourdomain.com/proxy/{base64-encoded-url}`
+
+## Troubleshooting
+
+- **Images not loading**: Check worker deployment and domain configuration
+- **CORS errors**: Ensure worker domain is properly configured
+- **Cache issues**: Worker includes cache headers for optimal performance

--- a/cloudflare-worker/wrangler.toml
+++ b/cloudflare-worker/wrangler.toml
@@ -1,0 +1,11 @@
+name = "notion-image-proxy"
+main = "worker.js"
+compatibility_date = "2024-03-08"
+account_id = "cf1bd4ae16c96d5e9bf794817c06f3cc"
+
+# Set this to your domain where the worker will be deployed
+# Example: notion-images.yourdomain.com
+# route = "notion-images.yourdomain.com/*"
+
+[env.production]
+name = "notion-image-proxy"

--- a/src/store/notionClient.ts
+++ b/src/store/notionClient.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { getProxiedImageUrl } from '../utils/imageProxy.js';
 
 
 const NOTION_SECRET = import.meta.env.NOTION_SECRET;
@@ -24,7 +25,7 @@ export const fetchNotionEvents = async () => {
             if (file.type === "external") {
                 headerImage = file.external.url;
             } else if (file.type === "file") {
-                headerImage = file.file.url;
+                headerImage = getProxiedImageUrl(file.file.url);
             }
         }
 
@@ -65,7 +66,7 @@ export const fetchNotionEventById = async (pageId: string) => {
         if (file.type === "external") {
             headerImage = file.external.url;
         } else if (file.type === "file") {
-            headerImage = file.file.url;
+            headerImage = getProxiedImageUrl(file.file.url);
         }
     }
 

--- a/src/utils/imageProxy.ts
+++ b/src/utils/imageProxy.ts
@@ -1,0 +1,36 @@
+// Utility for generating proxy URLs for Notion images
+// Replace with your actual worker domain after deployment
+const WORKER_DOMAIN = process.env.NOTION_IMAGE_PROXY_URL || 'https://notion-image-proxy.paul-cf1.workers.dev';
+
+/**
+ * Converts a Notion image URL to a proxied URL that won't expire
+ * @param notionUrl The original Notion S3 URL
+ * @returns Stable proxy URL
+ */
+export function getProxiedImageUrl(notionUrl: string): string {
+  // Return original URL if it's already a local path or external URL
+  if (!notionUrl || 
+      notionUrl.startsWith('/') || 
+      (!notionUrl.includes('s3.us-west-2.amazonaws.com') && 
+       !notionUrl.includes('prod-files-secure.s3'))) {
+    return notionUrl;
+  }
+
+  try {
+    // Encode the Notion URL in base64
+    const encodedUrl = btoa(notionUrl);
+    return `${WORKER_DOMAIN}/proxy/${encodedUrl}`;
+  } catch (error) {
+    console.error('Failed to encode Notion URL:', error);
+    return notionUrl; // Fallback to original URL
+  }
+}
+
+/**
+ * Batch convert multiple Notion URLs to proxy URLs
+ * @param urls Array of Notion URLs
+ * @returns Array of proxy URLs
+ */
+export function getProxiedImageUrls(urls: string[]): string[] {
+  return urls.map(url => getProxiedImageUrl(url));
+}


### PR DESCRIPTION
- Add Cloudflare Worker to proxy and cache Notion images
- Prevent image URLs from expiring after 1 hour
- Cache images at edge for 24 hours with 7-day stale-while-revalidate
- Update notionClient to use proxy URLs for Notion-hosted images
- Add imageProxy utility for URL generation
- Include deployment documentation and worker configuration

🤖 Generated with [Claude Code](https://claude.ai/code)