### PR TITLE
Fix image cropping on events page by using object-contain

### DIFF
--- a/src/components/Events.tsx
+++ b/src/components/Events.tsx
@@ -152,7 +152,7 @@ export default function Events({ events: initialEvents, loading = false }: Event
                                 <img
                                     src={event.image}
                                     alt={event.title}
-                                    className="rounded-xl w-full aspect-[4/3] object-cover"
+                                    className="rounded-xl w-full aspect-[4/3] object-contain bg-gray-100"
                                     crossOrigin="anonymous"
                                     onError={(e) => {
                                         const target = e.target as HTMLImageElement;


### PR DESCRIPTION
- Changed from object-cover to object-contain to show full images without cropping
- Added light gray background for consistent appearance when images don't fill container
- Maintains existing 4:3 aspect ratio and styling

🤖 Generated with [Claude Code](https://claude.ai/code)