### PR TITLE
Add e4p-sign-up page with Calendly embeds

### DIFF
--- a/src/pages/e4p-sign-up.astro
+++ b/src/pages/e4p-sign-up.astro
@@ -1,0 +1,53 @@
+---
+import Layout from "../layouts/Layout.astro";
+import React from "react";
+import "../styles/base.css";
+---
+
+<Layout>
+    <div class="container mx-auto px-4 py-10 max-w-6xl">
+        {/* Title + Intro */}
+        <h2 class="text-4xl font-bold text-center mb-4">
+            Entrepreneurs for Palestine - Sign Up
+        </h2>
+        <p class="text-lg text-center max-w-3xl mx-auto mb-12 text-gray-700">
+            If you're an entrepreneur, schedule a short introductory call based on your region.
+            Please include your company, position, and LinkedIn URL for verification.
+        </p>
+
+        {/* Sign Up + Calendars */}
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-8 mb-10">
+            <div>
+                <h3 class="text-xl font-semibold text-center mb-4">
+                    Americas
+                </h3>
+                <div class="h-[600px] w-full rounded-lg overflow-hidden shadow-lg">
+                    <iframe
+                        title="Calendly Americas"
+                        src="https://calendly.com/hsyed-hsyedlegal/entrepreneurs-for-palestine?background_color=ffffff&text_color=1a1a1a&primary_color=cf1026"
+                        width="100%"
+                        height="100%"
+                        frameborder="0"
+                        allow="fullscreen">
+                    </iframe>
+                </div>
+            </div>
+
+            <div>
+                <h3 class="text-xl font-semibold text-center mb-4">
+                    Europe / Asia
+                </h3>
+                <div class="h-[600px] w-full rounded-lg overflow-hidden shadow-lg">
+                    <iframe
+                        title="Calendly Europe/Asia"
+                        src="https://calendly.com/iva-techforpalestine/30min?background_color=ffffff&text_color=1a1a1a&primary_color=cf1026"
+                        width="100%"
+                        height="100%"
+                        frameborder="0"
+                        allow="fullscreen">
+                    </iframe>
+                </div>
+            </div>
+        </div>
+    </div>
+</Layout>

--- a/src/pages/e4p-sign-up.astro
+++ b/src/pages/e4p-sign-up.astro
@@ -11,8 +11,7 @@ import "../styles/base.css";
             Entrepreneurs for Palestine - Sign Up
         </h2>
         <p class="text-lg text-center max-w-3xl mx-auto mb-12 text-gray-700">
-            If you're an entrepreneur, schedule a short introductory call based on your region.
-            Please include your company, position, and LinkedIn URL for verification.
+            If you are an entrepreneur and you wish to become part of our community, you can sign up using one of the form below to schedule an introductory call, depending on your location and time zone. Please insert your company, position, and Linkedin URL for verification purposes.
         </p>
 
         {/* Sign Up + Calendars */}


### PR DESCRIPTION
- Create dedicated sign-up page for Entrepreneurs for Palestine
- Include Americas and Europe/Asia Calendly scheduling widgets
- Match existing site styling with Tailwind CSS classes
- Use same embed URLs as main E4P page

🤖 Generated with [Claude Code](https://claude.ai/code)