### PR TITLE
Fix API caching: disable prerender, add Cloudflare cache controls

### DIFF
--- a/_headers
+++ b/_headers
@@ -1,0 +1,6 @@
+/api/*
+  Cache-Control: no-cache, no-store, must-revalidate, max-age=0, s-maxage=0
+  Pragma: no-cache
+  Expires: 0
+  Vary: *
+  CF-Cache-Status: DYNAMIC

--- a/src/pages/api/projects-new.ts
+++ b/src/pages/api/projects-new.ts
@@ -1,13 +1,29 @@
 import type { APIRoute } from 'astro';
 
+// Explicitly disable prerendering for this API route
+export const prerender = false;
+
 export const GET: APIRoute = async ({ request }) => {
   try {
     console.log('API: Starting fetchProjectsFromApp...');
     
+    // Force fresh fetch with comprehensive cache-busting
     const response = await fetch('https://projecthub.techforpalestine.org/api/public/projects', {
+      method: 'GET',
       headers: {
-        'Content-Type': 'application/json'
-      }
+        'Content-Type': 'application/json',
+        'Cache-Control': 'no-cache, no-store, must-revalidate',
+        'Pragma': 'no-cache',
+        'User-Agent': 'T4P-Website/1.0'
+      },
+      // Cloudflare-specific fetch options to bypass all caching
+      cf: {
+        cacheEverything: false,
+        cacheTtl: 0,
+        cacheTtlByStatus: {}
+      },
+      // Standard fetch cache control
+      cache: 'no-store'
     });
 
     if (!response.ok) {
@@ -40,11 +56,17 @@ export const GET: APIRoute = async ({ request }) => {
         'Access-Control-Allow-Origin': '*',
         'Access-Control-Allow-Methods': 'GET',
         'Access-Control-Allow-Headers': 'Content-Type',
-        'Cache-Control': 'no-cache, no-store, must-revalidate',
+        // Comprehensive cache control headers
+        'Cache-Control': 'no-cache, no-store, must-revalidate, max-age=0, s-maxage=0',
         'Pragma': 'no-cache',
         'Expires': '0',
+        // Cloudflare-specific headers
+        'CF-Cache-Status': 'DYNAMIC',
+        'Vary': '*',
+        // Custom headers for debugging
         'X-Project-Count': projects.length.toString(),
         'X-Fetch-Time': new Date().toISOString(),
+        'X-Cache-Bust': Date.now().toString(),
       },
     });
   } catch (error) {


### PR DESCRIPTION
## Summary
- Fixes production caching issues preventing project status updates from appearing
- Adds comprehensive Cloudflare Pages cache bypass controls
- Ensures real-time data updates from external ProjectHub API

## Changes Made
- **API Route Enhanced**: Added `prerender = false` and Cloudflare-specific fetch options
- **Cache Headers**: Comprehensive cache control including `CF-Cache-Status: DYNAMIC`
- **Deployment Rules**: Created `_headers` file for Cloudflare Pages cache bypass on `/api/*`
- **Debugging**: Added cache-busting timestamp and fetch-time headers

## Test plan
- [x] Verify external API returns 65 projects with correct status updates
- [ ] Deploy and confirm `cf-cache-status` headers show `DYNAMIC` or `MISS`
- [ ] Verify project status updates appear immediately after deployment
- [ ] Check browser dev tools for cache-busting headers

## Root Cause
External API had correct data, but Cloudflare Pages was caching stale responses despite `no-cache` headers. Multiple caching layers needed to be disabled:
1. Build-time prerendering 
2. Cloudflare edge caching
3. Function-level fetch caching

🤖 Generated with [Claude Code](https://claude.ai/code)