### PR TITLE
Fix project logo images not displaying

### DIFF
--- a/src/components/ProjectsNew.tsx
+++ b/src/components/ProjectsNew.tsx
@@ -143,7 +143,17 @@ export default function ProjectsNew({ projects: initialProjects, loading: initia
                             {/* Project Image */}
                             <Box className="relative w-full">
                                 <img
-                                    src={project.logoUrl || "/images/default.jpg"}
+                                    src={(() => {
+                                        if (!project.logoUrl || project.logoUrl.trim() === "") {
+                                            return "/images/default.jpg";
+                                        }
+                                        // If logoUrl is a relative path, prepend the ProjectHub domain
+                                        if (project.logoUrl.startsWith("/")) {
+                                            return `https://projecthub.techforpalestine.org${project.logoUrl}`;
+                                        }
+                                        // If it's already a full URL, use as-is
+                                        return project.logoUrl;
+                                    })()}
                                     alt={project.name}
                                     className="rounded-xl w-full aspect-[16/9] object-cover bg-gray-100"
                                     onError={(e) => {


### PR DESCRIPTION
## Summary
- Fixes issue where projects with logos still show default placeholder image
- Converts relative logoUrl paths to full URLs pointing to ProjectHub domain
- Maintains existing fallback logic for empty/null values

## Changes Made
- **Image URL Resolution**: Detects relative paths starting with "/" and prepends "https://projecthub.techforpalestine.org"
- **Backward Compatibility**: Full URLs and empty values handled as before
- **Error Handling**: Existing onError fallback to default image preserved

## Test plan
- [x] Verified logos exist at ProjectHub URLs (e.g., /uploads/logos/logo-52b8ca01cbe29e7c-1754924893615.png)
- [ ] Confirm "ProjectHub" and "Boon Digital Solutions" display actual logos
- [ ] Verify projects without logos still show default placeholder
- [ ] Test error fallback still works for broken image URLs

## Root Cause
External API returns relative paths like `/uploads/logos/...` for logoUrl, but component was trying to load them from the current domain instead of the ProjectHub domain where they're hosted.

🤖 Generated with [Claude Code](https://claude.ai/code)