### PR TITLE
Restore floating donate button

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -46,6 +46,22 @@ const {
 <body class="text-gray-900 bg-white min-h-screen relative flex flex-col">
 <Navigation />
 
+<!-- Floating Donate Button -->
+<a
+    href="/donate"
+    class="fixed right-0 top-1/2 transform -translate-y-1/2 text-white px-2 py-6 shadow-lg hover:bg-green-900 transition z-50 bg-green-800"
+    style="
+    writing-mode: sideways-lr;
+    text-orientation: mixed;
+    border-top-left-radius: 0.5rem;
+    border-bottom-left-radius: 0.5rem;
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+  "
+>
+    Donate
+</a>
+
 <div class="flex-grow">
 <slot />
 </div>


### PR DESCRIPTION
## Summary
- Re-add the sticky donate button that was accidentally removed in commit 353cd1b
- Button appears fixed on the right edge, vertically centered
- Persists as users scroll through all pages

## Test plan
- [x] Verify button appears on all pages
- [x] Test button positioning and styling
- [x] Confirm donate link functionality

🤖 Generated with [Claude Code](https://claude.ai/code)