### PR TITLE
Fix: Hide registration links for past events

### DIFF
--- a/src/components/Events.tsx
+++ b/src/components/Events.tsx
@@ -286,7 +286,7 @@ export default function Events({ events: initialEvents, loading: initialLoading 
                                 {/* Footer */}
                                 <Box className="flex flex-wrap items-center justify-between pt-2 gap-4">
                                     <Box className="flex gap-3 text-sm">
-                                        {event.registerLink && (
+                                        {event.registerLink && !isPast && (
                                             <Link
                                                 href={event.registerLink}
                                                 target="_blank"


### PR DESCRIPTION
## Summary
- Fixed issue where registration links were showing for events with status "Past"
- Added condition to only display registration links when event is not past

## Test plan
- [ ] Load events page and verify past events no longer show registration links
- [ ] Verify upcoming/active events still show registration links when available
- [ ] Verify recording links still show for past events (unchanged)