### PR TITLE
fix: remove crossOrigin attribute to prevent CORS errors on event images

### DIFF
--- a/src/components/Events.tsx
+++ b/src/components/Events.tsx
@@ -188,7 +188,6 @@ export default function Events({ events: initialEvents, loading: initialLoading 
                                     src={event.image}
                                     alt={event.title}
                                     className="rounded-xl w-full aspect-[4/3] object-contain bg-gray-100"
-                                    crossOrigin="anonymous"
                                     onLoad={(e) => {
                                         const target = e.target as HTMLImageElement;
                                         console.log(`Image loaded successfully for event "${event.title}":`, target.src);


### PR DESCRIPTION
## Summary
- Removes `crossOrigin="anonymous"` from event images in Events.tsx
- Fixes CORS errors when loading images from external domains without proper CORS headers

## Test plan
- [ ] Verify event images load without CORS errors in browser console
- [ ] Test on localhost and production environments