### PR TITLE
fix: disable prerendering for FAQ and events API routes

### DIFF
--- a/src/pages/api/events.ts
+++ b/src/pages/api/events.ts
@@ -1,6 +1,9 @@
 import type { APIRoute } from 'astro';
 import { fetchNotionEvents } from '../../store/notionClient';
 
+export const prerender = false;
+
+
 export const GET: APIRoute = async ({ request }) => {
   try {
       const url = new URL(request.url);

--- a/src/pages/api/faq.ts
+++ b/src/pages/api/faq.ts
@@ -1,6 +1,8 @@
 import type { APIRoute } from 'astro';
 import { fetchNotionFAQ } from '../../store/notionClient';
 
+export const prerender = false;
+
 export const GET: APIRoute = async ({request}) => {
     try {
         const url = new URL(request.url);


### PR DESCRIPTION
## Summary
- Add `export const prerender = false` to FAQ and events API routes
- Prevents static generation to ensure dynamic behavior

## Test plan
- [ ] Verify API routes respond dynamically
- [ ] Test FAQ and events endpoints