### PR TITLE
fix: reverse FAQ order and remove default sorting

### DIFF
--- a/src/store/notionClient.ts
+++ b/src/store/notionClient.ts
@@ -179,12 +179,6 @@ export const fetchNotionFAQ = async (showAll: boolean = false, locals?: any) => 
     
     const notionAxios = createNotionAxios(secret);
     const queryBody = {
-        sorts: [
-            {
-                property: "Question",
-                direction: "ascending"
-            }
-        ],
         ...(showAll ? {} : {
             filter: {
                 property: "Visibility",
@@ -210,5 +204,5 @@ export const fetchNotionFAQ = async (showAll: boolean = false, locals?: any) => 
         };
     });
 
-    return faqs;
+    return faqs.reverse();
 };


### PR DESCRIPTION
## Summary
• Removes explicit Question property sorting from Notion query
• Reverses the results array to display FAQs in reverse chronological order

## Test plan
- [x] Verify FAQ page displays items in correct order
- [x] Test that FAQ functionality works as expected