### PR TITLE
Centralize environment variable handling with getEnv utility

### DIFF
--- a/src/pages/api/e4p-pledge-sign.ts
+++ b/src/pages/api/e4p-pledge-sign.ts
@@ -1,8 +1,9 @@
 import type { APIRoute } from 'astro';
 import { Client } from '@notionhq/client';
+import { getEnv } from '../../utils/getEnv.js';
 
 const notion = new Client({ 
-  auth: import.meta.env.NOTION_SECRET 
+  auth: getEnv('NOTION_SECRET')
 });
 
 export const prerender = false;
@@ -31,7 +32,7 @@ export const POST: APIRoute = async ({ request }) => {
       });
     }
 
-    const databaseId = import.meta.env.NOTION_SIGNATORIES_DB_ID;
+    const databaseId = getEnv('NOTION_SIGNATORIES_DB_ID');
     
     if (!databaseId) {
       throw new Error("NOTION_SIGNATORIES_DB_ID not configured");

--- a/src/pages/api/e4p-signatories.ts
+++ b/src/pages/api/e4p-signatories.ts
@@ -1,15 +1,16 @@
 import type { APIRoute } from 'astro';
 import { Client } from '@notionhq/client';
+import { getEnv } from '../../utils/getEnv.js';
 
 const notion = new Client({ 
-  auth: import.meta.env.NOTION_SECRET 
+  auth: getEnv('NOTION_SECRET')
 });
 
 export const prerender = false;
 
 export const GET: APIRoute = async () => {
   try {
-    const databaseId = import.meta.env.NOTION_SIGNATORIES_DB_ID;
+    const databaseId = getEnv('NOTION_SIGNATORIES_DB_ID');
     
     if (!databaseId) {
       throw new Error("NOTION_SIGNATORIES_DB_ID not configured");

--- a/src/pages/api/projects-new.ts
+++ b/src/pages/api/projects-new.ts
@@ -1,12 +1,13 @@
 import type { APIRoute } from 'astro';
+import { getEnv } from '../../utils/getEnv.js';
 
 // Import environment variables properly for Astro
-const PROJECTHUB_API_KEY = import.meta.env.PROJECTHUB_API_KEY || process.env.PROJECTHUB_API_KEY;
+const PROJECTHUB_API_KEY = getEnv('PROJECTHUB_API_KEY');
 
 // Explicitly disable prerendering for this API route
 export const prerender = false;
 
-export const GET: APIRoute = async ({ request }) => {
+export const GET: APIRoute = async () => {
   try {
     console.log('API: Starting fetchProjectsFromApp...');
     console.log('API: API Key available:', !!PROJECTHUB_API_KEY);

--- a/src/store/api.ts
+++ b/src/store/api.ts
@@ -1,10 +1,11 @@
 import axios from 'axios';
+import { getEnv } from '../utils/getEnv.js';
 
-const API_URL = import.meta.env.PUBLIC_API_URL;
-const SECRET_KEY = import.meta.env.PUBLIC_SECRET_KEY;
+const API_URL = getEnv('PUBLIC_API_URL');
+const SECRET_KEY = getEnv('PUBLIC_SECRET_KEY');
 
-console.log('PUBLIC_API_URL:', import.meta.env.PUBLIC_API_URL);
-console.log('PUBLIC_SECRET_KEY:', import.meta.env.PUBLIC_SECRET_KEY);
+console.log('PUBLIC_API_URL:', API_URL);
+console.log('PUBLIC_SECRET_KEY:', SECRET_KEY);
 
 // Define Axios instance with headers
 const axiosInstance = axios.create({

--- a/src/store/notionClient.ts
+++ b/src/store/notionClient.ts
@@ -1,35 +1,6 @@
 import axios from 'axios';
 import { getProxiedImageUrl } from '../utils/imageProxy.js';
-
-// Helper function to get environment variables with proper fallbacks
-function getEnvVar(name: string, locals?: any): string | undefined {
-  // Try Cloudflare Pages runtime context first (for production)
-  if (locals?.runtime?.env?.[name]) {
-    return locals.runtime.env[name];
-  }
-  
-  // Try Astro's import.meta.env (for build-time variables)
-  if (import.meta.env[name]) {
-    return import.meta.env[name];
-  }
-  
-  // Try Node.js process.env (for development and server environments)
-  if (typeof process !== 'undefined' && process.env?.[name]) {
-    return process.env[name];
-  }
-  
-  // Try global environment (for Cloudflare Workers)
-  if (typeof globalThis !== 'undefined' && (globalThis as any).process?.env?.[name]) {
-    return (globalThis as any).process.env[name];
-  }
-  
-  // Try accessing directly from globalThis (some Cloudflare environments)
-  if (typeof globalThis !== 'undefined' && (globalThis as any)[name]) {
-    return (globalThis as any)[name];
-  }
-  
-  return undefined;
-}
+import { getEnv } from '../utils/getEnv.js';
 
 // Helper function to create Notion axios instance with runtime environment variables
 function createNotionAxios(secret: string) {
@@ -44,8 +15,8 @@ function createNotionAxios(secret: string) {
 }
 
 export const fetchNotionEvents = async (showAll: boolean = false, locals?: any) => {
-    const secret = getEnvVar('NOTION_SECRET', locals);
-    const dbId = getEnvVar('NOTION_DB_ID', locals);
+    const secret = getEnv('NOTION_SECRET', locals);
+    const dbId = getEnv('NOTION_DB_ID', locals);
     
     if (!secret || !dbId) {
         throw new Error('Missing Notion credentials: NOTION_SECRET and NOTION_DB_ID are required');
@@ -120,7 +91,7 @@ export const fetchNotionEvents = async (showAll: boolean = false, locals?: any) 
 };
 
 export const fetchNotionEventById = async (pageId: string, locals?: any) => {
-    const secret = getEnvVar('NOTION_SECRET', locals);
+    const secret = getEnv('NOTION_SECRET', locals);
     
     if (!secret) {
         throw new Error('Missing Notion credentials: NOTION_SECRET is required');
@@ -170,8 +141,8 @@ export const fetchNotionEventById = async (pageId: string, locals?: any) => {
 };
 
 export const fetchNotionFAQ = async (showAll: boolean = false, locals?: any) => {
-    const secret = getEnvVar('NOTION_SECRET', locals);
-    const faqDbId = getEnvVar('NOTION_FAQ_DB_ID', locals);
+    const secret = getEnv('NOTION_SECRET', locals);
+    const faqDbId = getEnv('NOTION_FAQ_DB_ID', locals);
     
     if (!secret || !faqDbId) {
         throw new Error('Missing Notion credentials: NOTION_SECRET and NOTION_FAQ_DB_ID are required');

--- a/src/utils/getEnv.ts
+++ b/src/utils/getEnv.ts
@@ -1,0 +1,29 @@
+// Helper function to get environment variables with proper fallbacks
+export function getEnv(name: string, locals?: any): string | undefined {
+  // Try Cloudflare Pages runtime context first (for production)
+  if (locals?.runtime?.env?.[name]) {
+    return locals.runtime.env[name];
+  }
+  
+  // Try Astro's import.meta.env (for build-time variables)
+  if (import.meta.env[name]) {
+    return import.meta.env[name];
+  }
+  
+  // Try Node.js process.env (for development and server environments)
+  if (typeof process !== 'undefined' && process.env?.[name]) {
+    return process.env[name];
+  }
+  
+  // Try global environment (for Cloudflare Workers)
+  if (typeof globalThis !== 'undefined' && (globalThis as any).process?.env?.[name]) {
+    return (globalThis as any).process.env[name];
+  }
+  
+  // Try accessing directly from globalThis (some Cloudflare environments)
+  if (typeof globalThis !== 'undefined' && (globalThis as any)[name]) {
+    return (globalThis as any)[name];
+  }
+  
+  return undefined;
+}

--- a/src/utils/imageProxy.ts
+++ b/src/utils/imageProxy.ts
@@ -1,6 +1,8 @@
+import { getEnv } from './getEnv.js';
+
 // Utility for generating proxy URLs for Notion images
 // Replace with your actual worker domain after deployment
-const WORKER_DOMAIN = process.env.NOTION_IMAGE_PROXY_URL || 'https://notion-image-proxy.paul-cf1.workers.dev';
+const WORKER_DOMAIN = getEnv('NOTION_IMAGE_PROXY_URL') || 'https://notion-image-proxy.paul-cf1.workers.dev';
 
 /**
  * Converts a Notion image URL to a proxied URL that won't expire


### PR DESCRIPTION
## Summary
- Created centralized `getEnv` utility in `src/utils/getEnv.ts`
- Replaced duplicate `getEnvVar` function with centralized utility
- Updated all files using environment variables to use consistent `getEnv` function
- Provides proper fallbacks for different runtime environments (Cloudflare Pages, Astro, Node.js, Workers)

## Test plan
- [ ] Verify dev server starts without errors
- [ ] Test API routes that use environment variables
- [ ] Confirm environment variables are properly resolved in different deployment contexts