### PR TITLE
feat: implement A/B test redirect for donation pages

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -50,7 +50,7 @@ const {
 <!-- Floating Donate Button -->
 <a
     href="/donate"
-    class="fixed right-0 top-1/2 transform -translate-y-1/2 text-white px-2 py-6 shadow-lg hover:bg-green-900 transition z-50 bg-green-800"
+    class="donate-link fixed right-0 top-1/2 transform -translate-y-1/2 text-white px-2 py-6 shadow-lg hover:bg-green-900 transition z-50 bg-green-800"
     style="
     writing-mode: sideways-lr;
     text-orientation: mixed;
@@ -67,5 +67,17 @@ const {
 <slot />
 </div>
 <Footer />
+
+<script is:inline>
+    // A/B test for donate links: 50% redirect to /donate, 50% to /donate-2
+    document.addEventListener('click', function(e) {
+        const target = e.target.closest('a[href="/donate"]');
+        if (target) {
+            e.preventDefault();
+            const destination = Math.random() < 0.5 ? '/donate' : '/donate-2';
+            window.location.href = destination;
+        }
+    });
+</script>
 </body>
 </html>

--- a/src/pages/donate-2.astro
+++ b/src/pages/donate-2.astro
@@ -3,7 +3,7 @@ import Layout from "../layouts/Layout.astro";
 import "../styles/base.css";
 ---
 
-<Layout title="Donate - Form 2">
+<Layout title="Donate">
     <div class="relative bg-gradient-to-b from-green-50 via-white to-blue-50">
         <div class="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8 py-12 sm:py-16">
             <!-- Hero -->

--- a/src/pages/donate.astro
+++ b/src/pages/donate.astro
@@ -111,11 +111,5 @@ import "../styles/base.css";
             </div>
         </div>
 
-        <script is:inline>
-            // A/B test redirect: 50% of users go to /donate-2 (Bloomerang)
-            if (Math.random() < 0.5) {
-                window.location.href = '/donate-2';
-            }
-        </script>
         <script is:inline defer id="charitystack-embed" data-id="M_lDGj72xT61" src="https://prod-donation-elements-b-donationelementsjsfilesb-1m4f4dl6p6b21.s3.us-east-2.amazonaws.com/bundle.js"></script>
     </Layout>

--- a/src/pages/donate.astro
+++ b/src/pages/donate.astro
@@ -56,12 +56,7 @@ import "../styles/base.css";
                             <h2 class="text-xl font-semibold text-gray-800 mb-4 text-center">Make a donation</h2>
                             <div class="w-full max-w-lg mx-auto">
                                 <!-- CharityStack Form -->
-                                <div id="charitystack-form-wrapper">
-                                    <div data-entity="EMBED_FORM" data-source="CharityStack" id="1546c2c2-a580-4994-bbb3-9e643aed1309"></div>
-                                </div>
-
-                                <!-- Bloomerang Form -->
-                                <div id="bloomerang-form-wrapper" class="qgiv-embed-container" data-qgiv-embed="true" data-embed-id="83460" data-embed="https://secure.qgiv.com/for/techforpalestine-websitedonationform/embed/83460/amount/1620629/recurring/" data-width="630"></div>
+                                <div data-entity="EMBED_FORM" data-source="CharityStack" id="1546c2c2-a580-4994-bbb3-9e643aed1309"></div>
                             </div>
                             <div class="mt-5 flex flex-col sm:flex-row items-center justify-center gap-3 text-sm text-gray-600">
                                 <div class="flex items-center">
@@ -117,36 +112,10 @@ import "../styles/base.css";
         </div>
 
         <script is:inline>
-            document.addEventListener("DOMContentLoaded", function () {
-                // A/B test: randomly assign 50% to each form
-                const showCharityStack = Math.random() < 0.5;
-
-                const charitystackWrapper = document.getElementById("charitystack-form-wrapper");
-                const bloomerangWrapper = document.getElementById("bloomerang-form-wrapper");
-
-                if (!charitystackWrapper || !bloomerangWrapper) return;
-
-                if (showCharityStack) {
-                    // Show CharityStack, hide Bloomerang
-                    bloomerangWrapper.style.display = "none";
-
-                    // Load CharityStack script
-                    const script = document.createElement("script");
-                    script.defer = true;
-                    script.id = "charitystack-embed";
-                    script.dataset.id = "M_lDGj72xT61";
-                    script.src = "https://prod-donation-elements-b-donationelementsjsfilesb-1m4f4dl6p6b21.s3.us-east-2.amazonaws.com/bundle.js";
-                    document.body.appendChild(script);
-                } else {
-                    // Show Bloomerang, hide CharityStack
-                    charitystackWrapper.style.display = "none";
-
-                    // Load Bloomerang (qgiv) script
-                    const script = document.createElement("script");
-                    script.id = "qgiv-embedjs";
-                    script.src = "https://secure.qgiv.com/resources/core/js/embed.js";
-                    document.body.appendChild(script);
-                }
-            });
+            // A/B test redirect: 50% of users go to /donate-2 (Bloomerang)
+            if (Math.random() < 0.5) {
+                window.location.href = '/donate-2';
+            }
         </script>
+        <script is:inline defer id="charitystack-embed" data-id="M_lDGj72xT61" src="https://prod-donation-elements-b-donationelementsjsfilesb-1m4f4dl6p6b21.s3.us-east-2.amazonaws.com/bundle.js"></script>
     </Layout>


### PR DESCRIPTION
## Summary
Split donation forms into two separate pages with 50/50 traffic distribution via client-side redirect:
- `/donate`: CharityStack form (50% of traffic stays here)
- `/donate-2`: Bloomerang/Qgiv form (50% of traffic redirected here)

## Changes
- Renamed `donate-form-2.astro` to `donate-2.astro`
- Updated `/donate` to show only CharityStack form
- Added client-side redirect logic for 50/50 A/B test split
- Simplified script loading for CharityStack embed

## Approach
Instead of showing/hiding forms on the same page, users are now randomly redirected to one of two separate donation pages. This provides cleaner separation between the two form providers and simplifies tracking.

## Test plan
- [x] Verify CharityStack form loads correctly on `/donate`
- [x] Verify Bloomerang/Qgiv form loads correctly on `/donate-2`
- [x] Test donation flow on both pages