### PR TITLE
feat: add Plausible A/B test tracking for donate forms

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -68,16 +68,5 @@ const {
 </div>
 <Footer />
 
-<script is:inline>
-    // A/B test for donate links: 50% redirect to /donate, 50% to /donate-2
-    document.addEventListener('click', function(e) {
-        const target = e.target.closest('a[href="/donate"]');
-        if (target) {
-            e.preventDefault();
-            const destination = Math.random() < 0.5 ? '/donate' : '/donate-2';
-            window.location.href = destination;
-        }
-    });
-</script>
 </body>
 </html>

--- a/src/pages/donate-2.astro
+++ b/src/pages/donate-2.astro
@@ -111,4 +111,10 @@ import "../styles/base.css";
     </div>
 
     <script>(function(w, d, s, id){var js, fjs = d.getElementsByTagName(s)[0];if (d.getElementById(id)) return;js = d.createElement(s); js.id = id;(js as HTMLScriptElement).src = "https://secure.qgiv.com/resources/core/js/embed.js";fjs.parentNode?.insertBefore(js, fjs);})(window, document, 'script', 'qgiv-embedjs');</script>
+
+    <script is:inline>
+        // Track which donate form variant the user sees
+        window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) };
+        window.plausible('pageview', { props: { donate_form_variant: 'qgiv' } });
+    </script>
 </Layout>

--- a/src/pages/donate.astro
+++ b/src/pages/donate.astro
@@ -55,8 +55,14 @@ import "../styles/base.css";
                         <div class="bg-white/80 backdrop-blur rounded-2xl border border-gray-200 shadow-md p-6 sm:p-8">
                             <h2 class="text-xl font-semibold text-gray-800 mb-4 text-center">Make a donation</h2>
                             <div class="w-full max-w-lg mx-auto">
-                                <!-- CharityStack Form -->
-                                <div data-entity="EMBED_FORM" data-source="CharityStack" id="1546c2c2-a580-4994-bbb3-9e643aed1309"></div>
+                                <!-- CharityStack Form (Variant A) -->
+                                <div id="form-variant-charitystack" style="display: none;">
+                                    <div data-entity="EMBED_FORM" data-source="CharityStack" id="1546c2c2-a580-4994-bbb3-9e643aed1309"></div>
+                                </div>
+                                <!-- Qgiv Form (Variant B) -->
+                                <div id="form-variant-qgiv" style="display: none;">
+                                    <div class="qgiv-embed-container" data-qgiv-embed="true" data-embed-id="83460" data-embed="https://secure.qgiv.com/for/techforpalestine-websitedonationform/embed/83460/amount/1620629/recurring/" data-width="630"></div>
+                                </div>
                             </div>
                             <div class="mt-5 flex flex-col sm:flex-row items-center justify-center gap-3 text-sm text-gray-600">
                                 <div class="flex items-center">
@@ -112,4 +118,18 @@ import "../styles/base.css";
         </div>
 
         <script is:inline defer id="charitystack-embed" data-id="M_lDGj72xT61" src="https://prod-donation-elements-b-donationelementsjsfilesb-1m4f4dl6p6b21.s3.us-east-2.amazonaws.com/bundle.js"></script>
+    <script is:inline>(function(w, d, s, id){var js, fjs = d.getElementsByTagName(s)[0];if (d.getElementById(id)) return;js = d.createElement(s); js.id = id;js.src = "https://secure.qgiv.com/resources/core/js/embed.js";fjs.parentNode?.insertBefore(js, fjs);})(window, document, 'script', 'qgiv-embedjs');</script>
+
+    <script is:inline>
+        // A/B test: randomly show one of two donation forms
+        window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) };
+
+        const variant = Math.random() < 0.5 ? 'charitystack' : 'qgiv';
+
+        // Show the selected form
+        document.getElementById('form-variant-' + variant).style.display = 'block';
+
+        // Track which variant was shown with Plausible custom property
+        window.plausible('pageview', { props: { donate_form_variant: variant } });
+    </script>
     </Layout>


### PR DESCRIPTION
Implement A/B testing on the donate page with Plausible custom properties to track which donation form variant (CharityStack vs Qgiv) users see. This allows proper analytics without needing separate URLs.