### PR TITLE
feat: sort FAQs by Position column in ascending order

### DIFF
--- a/src/store/notionClient.ts
+++ b/src/store/notionClient.ts
@@ -167,15 +167,18 @@ export const fetchNotionFAQ = async (showAll: boolean = false, locals?: any) => 
 
         const question = props["Question"]?.title?.[0]?.plain_text || "";
         const answer = props["Answer"]?.rich_text || [];
+        const position = props["Position"]?.number ?? 999999; // Default to high number if no position
 
         return {
             id: page.id,
             question,
             answer,
+            position,
         };
     });
 
-    return faqs.reverse();
+    // Sort by position ascending
+    return faqs.sort((a: any, b: any) => a.position - b.position);
 };
 
 export const fetchNotionIdeas = async (locals?: any) => {


### PR DESCRIPTION
## Summary
- Replace `.reverse()` with proper sorting by the `Position` property from Notion database
- Extract the Position column value from each FAQ entry
- Sort FAQs in ascending order (lowest position first)
- FAQs without a position value default to 999999 to appear at the end

## Changes
- Modified `fetchNotionFAQ()` in [notionClient.ts](src/store/notionClient.ts) to:
  - Extract the `Position` number property from Notion
  - Sort by position ascending instead of reversing the array
  - Handle missing positions gracefully with a default value

## Test plan
- [x] Verify FAQs appear in the order set by the Position column in Notion
- [x] Verify FAQs without a position appear at the end