### PR TITLE
Fix: Prevent timezone conversion in event date display

### DIFF
--- a/src/components/Events.tsx
+++ b/src/components/Events.tsx
@@ -172,11 +172,12 @@ export default function Events({ events: initialEvents, loading: initialLoading 
 
             <div className="space-y-6">
                 {events.map((event, i) => {
-                    const eventDate = new Date(event.date);
-                    const day = eventDate.getDate();
-                    const month = eventDate.toLocaleString("default", {
-                        month: "short",
-                    }).toUpperCase();
+                    // Parse date string without timezone conversion
+                    const [year, month, day] = event.date.split('-');
+                    const monthNames = ["JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "NOV", "DEC"];
+                    const monthName = monthNames[parseInt(month) - 1];
+                    const dayNum = parseInt(day);
+
                     const isPast = event.status?.toLowerCase() === "past";
                     const eventUrl = `/event-details?id=${event.id}`;
 
@@ -260,7 +261,7 @@ export default function Events({ events: initialEvents, loading: initialLoading 
                                 <Box className="flex flex-wrap items-center gap-4 text-sm text-gray-600">
                   <span className="flex items-center gap-1">
                     <CalendarTodayIcon fontSize="small" />
-                      {month} {day}, {eventDate.getFullYear()}
+                      {monthName} {dayNum}, {year}
                   </span>
                                     {event.time && (
                                         <span className="flex items-center gap-1">


### PR DESCRIPTION
## Summary
- Fixed event dates being shifted by timezone conversion
- Event dates now display exactly as stored in Notion without timezone shifts
- Replaced `new Date()` parsing with direct string manipulation

## Changes
- **Before**: Used `new Date(event.date)` which converted dates based on browser timezone, causing dates to shift (e.g., Oct 14 → Oct 13)
- **After**: Parse date string directly using `split('-')` to extract year, month, day without timezone conversion
- Date format maintained: "MMM DD, YYYY" (e.g., "OCT 14, 2025")

## Technical Details
The issue occurred because JavaScript's `new Date("2025-10-14")` interprets the date as UTC midnight, then converts to local timezone. For users in timezones behind UTC, this would shift the date backward by one day.

The fix uses pure string parsing:
```javascript
const [year, month, day] = event.date.split('-');
const monthNames = ["JAN", "FEB", "MAR", ...];
const monthName = monthNames[parseInt(month) - 1];
const dayNum = parseInt(day);
```

## Test Plan
- [x] Verify dates display correctly in the Events page
- [x] Check that dates match what's in Notion database
- [x] Test with events from different months