### PR TITLE
Add Vercel page link to footer Learn section

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -45,6 +45,7 @@ const footerNavigation: Record<string, { href?: string; links: [string, string][
             // ["Shopping Ethically", "/coming-soon"],
             // ["How to Boycott", "/coming-soon"],
             // ["Tech Complicity", "/coming-soon"],
+            ["Vercel", "/vercel"],
             ["FAQ", "/faq"]
         ]
     }


### PR DESCRIPTION
## Summary
- Added Vercel page link to the Learn section of the footer navigation

## Test plan
- [x] Verify link appears in footer Learn section
- [x] Verify link navigates to /vercel page correctly