### PR TITLE
Add media contact email to media page

### DIFF
--- a/src/pages/media.astro
+++ b/src/pages/media.astro
@@ -103,6 +103,21 @@ const newsletters = [
         <hr class="mx-auto mb-4 mt-6 h-1 w-1/2 border-none bg-gray-700" />
       </div>
 
+      <!-- Media Contact -->
+      <div class="mx-auto mt-8 max-w-2xl rounded-xl border border-gray-200 bg-gray-50 p-6 text-center shadow-sm">
+        <h4 class="mb-2 text-lg font-semibold text-gray-800">📧 Media Inquiries</h4>
+        <p class="mb-3 text-sm text-gray-700">
+          For press inquiries, interviews, or media requests, please contact:
+        </p>
+        <a
+          href="mailto:media@techforpalestine.org"
+          class="inline-flex items-center gap-2 text-blue-600 hover:underline"
+        >
+          <Icon name="mdi:email-outline" class="h-5 w-5" />
+          <span class="font-medium">media@techforpalestine.org</span>
+        </a>
+      </div>
+
       <!-- Press Kit Section -->
       <div class="mx-auto mt-12 max-w-6xl">
         <h3 class="mb-4 text-2xl font-semibold text-gray-900">🧰 Media Press Kit</h3>
@@ -178,21 +193,6 @@ const newsletters = [
             class="inline-block rounded-full bg-black px-6 py-3 text-white shadow transition hover:bg-zinc-800"
           >
             Download Full Press Kit (PDF)
-          </a>
-        </div>
-
-        <!-- Media Contact -->
-        <div class="mt-8 rounded-xl border border-gray-200 bg-gray-50 p-6 shadow-sm">
-          <h4 class="mb-2 text-lg font-semibold text-gray-800">📧 Media Inquiries</h4>
-          <p class="mb-3 text-sm text-gray-700">
-            For press inquiries, interviews, or media requests, please contact:
-          </p>
-          <a
-            href="mailto:media@techforpalestine.org"
-            class="inline-flex items-center gap-2 text-blue-600 hover:underline"
-          >
-            <Icon name="mdi:email-outline" class="h-5 w-5" />
-            <span class="font-medium">media@techforpalestine.org</span>
           </a>
         </div>
       </div>


### PR DESCRIPTION
Adds a media inquiries section to the press kit area with a mailto link to media@techforpalestine.org