### PR TITLE
Remove Vercel accountability banner from homepage

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -6,15 +6,6 @@ import ArrowIcon from "../components/ArrowIcon.astro";
 ---
 
 <Layout title="Tech For Palestine">
-  <!-- Vercel Accountability Banner -->
-  <div class="border-b-2 border-red-800 bg-red-100 px-4 py-3">
-    <div class="mx-auto max-w-7xl text-center">
-      <a href="/vercel" class="font-medium text-red-900 hover:text-red-800 hover:underline">
-        Vercel CEO aligned with genocide by supporting Netanyahu. Conference speakers chose
-        complicity. Learn more →
-      </a>
-    </div>
-  </div>
   <main>
     <section class="grid grid-cols-1 items-center bg-white lg:grid-cols-2">
       <div class="min-h-fit items-center justify-center space-y-12 py-16 text-center">


### PR DESCRIPTION
Removes the Vercel accountability banner from the homepage as it is no longer needed.