### PR TITLE
Add descriptive alt text to images on About page

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -165,7 +165,7 @@ import "../styles/base.css";
                 <div class="relative">
                   <img
                     src="/gaza-sky-geeks.webp"
-                    alt="Woman with laptop at Gaza Sky Geeks, building Palestine's digital economy through freelancer training across Gaza, West Bank, and East Jerusalem"
+                    alt="A woman working on a laptop at Gaza Sky Geeks technology center"
                     class="aspect-[2/3] w-full rounded-xl bg-gray-900/5 object-cover shadow-lg"
                   />
                   <div


### PR DESCRIPTION
Closes #311.

This is a pretty self-explanatory PR, so give all the alt text a review.

Alt text added for:

`src/pages/about.astro`

- Line 154-155: /protest-dc.jpg
- Line 167-168: /gaza-sky-geeks.webp
- Line 178-179: /jerusalem.jpg
- Line 191-192: /olive-branch-thobe.jpg
- Line 202-203: /gaza-father-child.avif
- Line 357-358: /gaza-children-playing-ocean.jpg