### PR TITLE
CSP: allow Calendly in frame-src for E4P sign-up page

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -25,7 +25,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
     "font-src 'self' https://fonts.gstatic.com",
     "img-src 'self' data: https:",
     "connect-src 'self' https://plausible.io https://pal-chat.net",
-    "frame-src https://secure.qgiv.com",
+    "frame-src https://secure.qgiv.com https://calendly.com",
     "object-src 'none'",
     "base-uri 'self'",
   ].join("; ");


### PR DESCRIPTION
## Summary
- Adds `https://calendly.com` to the `frame-src` CSP directive in `src/middleware.ts`
- Fixes blocked Calendly iframes on the E4P sign-up page (`/e4p/sign-up`)

## Test plan
- [x] Visit `/e4p/sign-up` and confirm both Calendly embeds (Americas and Europe/Asia) load without CSP errors in the browser console