### PR TITLE
Hide floating Donate tab on mobile

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -110,7 +110,7 @@ const canonicalUrl = new URL(
     <!-- Floating Donate Button -->
     <a
       href="/donate"
-      class="donate-link fixed right-0 top-1/2 z-50 bg-green-800 px-3 py-5 text-white shadow-lg transition hover:bg-green-900"
+      class="donate-link hidden md:block fixed right-0 top-1/2 z-50 bg-green-800 px-3 py-5 text-white shadow-lg transition hover:bg-green-900"
       style="
     writing-mode: vertical-rl;
     transform: translateY(-50%) rotate(180deg);


### PR DESCRIPTION
## Summary
- Hides the floating vertical "Donate" side tab on mobile screens (visible on `md:` and above)
- Reported to block content and make pages harder to read on small screens

## Test plan
- [x] Verify the Donate tab is hidden on mobile viewports
- [x] Verify the Donate tab still appears on desktop/tablet viewports