### PR TITLE
CSP: allow YouTube embeds and Cloudflare cdn-cgi script

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -20,12 +20,12 @@ export const onRequest = defineMiddleware(async (context, next) => {
   const csp = [
     "default-src 'self'",
     // 'strict-dynamic' trusts scripts loaded by nonced scripts; removes need for 'unsafe-inline'
-    `script-src 'nonce-${nonce}' 'strict-dynamic' https://secure.qgiv.com https://plausible.io https://pal-chat.net`,
+    `script-src 'nonce-${nonce}' 'strict-dynamic' https://secure.qgiv.com https://plausible.io https://pal-chat.net https://techforpalestine.org/cdn-cgi/`,
     "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
     "font-src 'self' https://fonts.gstatic.com",
     "img-src 'self' data: https:",
     "connect-src 'self' https://plausible.io https://pal-chat.net",
-    "frame-src https://secure.qgiv.com https://calendly.com",
+    "frame-src https://secure.qgiv.com https://calendly.com https://www.youtube.com https://www.youtube-nocookie.com",
     "object-src 'none'",
     "base-uri 'self'",
   ].join("; ");


### PR DESCRIPTION
## Summary
- Add `https://www.youtube.com` and `https://www.youtube-nocookie.com` to `frame-src` to fix blocked YouTube embeds
- Add `https://techforpalestine.org/cdn-cgi/` to `script-src` to fix blocked Cloudflare email obfuscation script