### PR TITLE
Remove Barcelona 2026 top banner and popup

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -68,43 +68,6 @@ const canonicalUrl = new URL(
     </script>
   </head>
   <body class="relative flex min-h-screen flex-col bg-white text-gray-900">
-    <!-- Barcelona 2026 Announcement Banner -->
-    <div
-      id="barcelona-banner"
-      class="relative flex items-center justify-center gap-3 bg-[#168039] px-4 py-2 text-sm text-white"
-    >
-      <span>Join the Tech for Palestine Conference in Barcelona on April 11th</span>
-      <a
-        href="https://barcelona2026.techforpalestine.org/"
-        target="_blank"
-        rel="noopener noreferrer"
-        class="rounded bg-white px-3 py-0.5 text-xs font-semibold text-[#168039] transition hover:bg-gray-100"
-      >
-        Learn more
-      </a>
-      <button
-        id="barcelona-banner-close"
-        aria-label="Dismiss banner"
-        class="absolute right-3 top-1/2 -translate-y-1/2 p-1 opacity-80 hover:opacity-100"
-      >
-        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
-          <path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd" />
-        </svg>
-      </button>
-    </div>
-    <script>
-      const BANNER_KEY = "barcelona-banner-dismissed";
-      const banner = document.getElementById("barcelona-banner");
-      const closeBtn = document.getElementById("barcelona-banner-close");
-      if (localStorage.getItem(BANNER_KEY)) {
-        banner?.remove();
-      }
-      closeBtn?.addEventListener("click", () => {
-        banner?.remove();
-        localStorage.setItem(BANNER_KEY, "1");
-      });
-    </script>
-
     <Navigation />
 
     <!-- Floating Donate Button -->

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -28,66 +28,6 @@ import "../styles/base.css";
       background-color: #15803d !important; /* green-700 */
     }
   </style>
-  <!-- Barcelona Event Popup -->
-  <div
-    id="barcelona-popup"
-    role="dialog"
-    aria-modal="true"
-    aria-label="Barcelona 2026 Event"
-    class="fixed inset-0 z-[1001] flex items-center justify-center bg-black/60 p-4"
-    style="display: none !important;"
-  >
-    <div class="relative max-w-2xl w-full">
-      <button
-        id="barcelona-popup-close"
-        class="absolute -top-3 -right-3 z-10 flex h-8 w-8 items-center justify-center rounded-full bg-white text-gray-800 shadow-lg hover:bg-gray-100 focus:outline-none"
-        aria-label="Close popup"
-      >
-        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
-          <path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd" />
-        </svg>
-      </button>
-      <a href="https://barcelona2026.techforpalestine.org/" target="_blank" rel="noopener noreferrer">
-        <img
-          src="/images/Barcelona Event.png"
-          alt="Tech for Palestine Barcelona 2026 Event"
-          class="w-full rounded-xl shadow-2xl"
-          loading="lazy"
-          width="1200"
-          height="1200"
-        />
-      </a>
-    </div>
-  </div>
-
-  <script>
-    const STORAGE_KEY = "barcelona-popup-dismissed";
-    const popup = document.getElementById("barcelona-popup");
-    const closeBtn = document.getElementById("barcelona-popup-close");
-
-    if (popup && !localStorage.getItem(STORAGE_KEY)) {
-      popup.style.removeProperty("display");
-      closeBtn?.focus();
-    }
-
-    function dismissPopup() {
-      if (popup) popup.style.display = "none";
-      localStorage.setItem(STORAGE_KEY, "1");
-    }
-
-    const ac = new AbortController();
-    const { signal } = ac;
-
-    closeBtn?.addEventListener("click", dismissPopup, { signal });
-    popup?.addEventListener("click", (e) => {
-      if (e.target === popup) dismissPopup();
-    }, { signal });
-    document.addEventListener("keydown", (e) => {
-      if (e.key === "Escape") dismissPopup();
-    }, { signal });
-    popup?.addEventListener("hidden", () => ac.abort(), { signal });
-  </script>
-
   <main>
     <section
       class="flex min-h-[calc(100vh-5rem)] flex-col-reverse bg-white lg:grid lg:grid-cols-2 lg:items-center"


### PR DESCRIPTION
## Summary
- Removes the Barcelona 2026 top announcement banner from the global layout
- Removes the Barcelona 2026 event popup from the homepage

The Barcelona conference was on April 11th and is now past.