### PR TITLE
security audit v5: project-proxy hardening & middleware consolidation

### DIFF
--- a/src/middleware/cache-control.ts
+++ b/src/middleware/cache-control.ts
@@ -1,0 +1,11 @@
+import { defineMiddleware } from "astro:middleware";
+
+export const cacheControl = defineMiddleware(async (context, next) => {
+  const response = await next();
+
+  const isApi = context.url.pathname.startsWith("/api/");
+  const isGet = context.request.method === "GET";
+  response.headers.set("Cache-Control", !isGet || isApi ? "no-store" : "public, max-age=600");
+
+  return response;
+});

--- a/src/middleware/csp.ts
+++ b/src/middleware/csp.ts
@@ -6,7 +6,7 @@ declare const HTMLRewriter: new () => {
   transform(response: Response): Response;
 };
 
-export const onRequest = defineMiddleware(async (context, next) => {
+export const csp = defineMiddleware(async (context, next) => {
   const nonce = crypto.randomUUID().replace(/-/g, "");
   context.locals.cspNonce = nonce;
 
@@ -17,7 +17,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
     return response;
   }
 
-  const csp = [
+  const cspHeader = [
     "default-src 'self'",
     // 'strict-dynamic' trusts scripts loaded by nonced scripts; removes need for 'unsafe-inline'
     `script-src 'nonce-${nonce}' 'strict-dynamic' https://secure.qgiv.com https://plausible.io https://pal-chat.net https://techforpalestine.org/cdn-cgi/`,
@@ -52,6 +52,6 @@ export const onRequest = defineMiddleware(async (context, next) => {
     });
 
   const transformed = rewriter.transform(response);
-  transformed.headers.set("Content-Security-Policy", csp);
+  transformed.headers.set("Content-Security-Policy", cspHeader);
   return transformed;
 });

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -1,11 +1,8 @@
-import { defineMiddleware } from "astro:middleware";
+import { sequence } from "astro:middleware";
+import { cacheControl } from "./cache-control.js";
+import { csp } from "./csp.js";
 
-export const onRequest = defineMiddleware(async (context, next) => {
-  const response = await next();
-
-  const isApi = context.url.pathname.startsWith("/api/");
-  const isGet = context.request.method === "GET";
-  response.headers.set("Cache-Control", !isGet || isApi ? "no-store" : "public, max-age=600");
-
-  return response;
-});
+// cacheControl runs first so the header is set on every response.
+// csp runs second and may replace the response via HTMLRewriter; the
+// cache-control header is preserved on the transformed response.
+export const onRequest = sequence(cacheControl, csp);

--- a/src/pages/api/project-proxy.ts
+++ b/src/pages/api/project-proxy.ts
@@ -39,10 +39,15 @@ async function proxy(request: Request, locals: unknown): Promise<Response> {
 
   const upstream = `${apiUrl.replace(/\/$/, "")}${normalizedPath}`;
 
-  const headers = new Headers(request.headers);
+  // Explicit allowlist — never forward cookies, IP headers, or other
+  // browser-supplied headers that could influence upstream access controls.
+  const FORWARD_HEADERS = ["content-type", "accept", "accept-language", "accept-encoding"];
+  const headers = new Headers();
+  for (const name of FORWARD_HEADERS) {
+    const val = request.headers.get(name);
+    if (val) headers.set(name, val);
+  }
   headers.set("Authorization", secretKey);
-  // Don't forward host header to the upstream
-  headers.delete("host");
 
   const upstreamResponse = await fetch(upstream, {
     method: request.method,

--- a/src/pages/api/project-proxy.ts
+++ b/src/pages/api/project-proxy.ts
@@ -26,14 +26,18 @@ async function proxy(request: Request, locals: unknown): Promise<Response> {
   const url = new URL(request.url);
   const path = url.searchParams.get("path");
 
-  if (!path || !path.startsWith("/api/method/")) {
+  // Normalise dot-segments (../, ./) before the prefix check so a crafted
+  // path like /api/method/../../api/auth/admin cannot bypass the guard.
+  const normalizedPath = path ? new URL(path, "http://localhost").pathname : null;
+
+  if (!normalizedPath || !normalizedPath.startsWith("/api/method/")) {
     return new Response(JSON.stringify({ error: "Path not allowed" }), {
       status: 403,
       headers: { "Content-Type": "application/json" },
     });
   }
 
-  const upstream = `${apiUrl.replace(/\/$/, "")}${path}`;
+  const upstream = `${apiUrl.replace(/\/$/, "")}${normalizedPath}`;
 
   const headers = new Headers(request.headers);
   headers.set("Authorization", secretKey);


### PR DESCRIPTION
## Summary

- **P-2 (Medium)** — Normalise dot-segments in `project-proxy` path before prefix check to prevent traversal bypass (`/api/method/../../api/auth/admin`)
- **L-5 (Low)** — Replace full header passthrough with explicit allowlist in `project-proxy`, blocking injection of `Cookie`, `X-Forwarded-For`, `CF-Connecting-IP`, etc.
- **M-6 (Medium)** — Consolidate dual middleware files: `src/middleware.ts` (CSP, active) and `src/middleware/index.ts` (cache-control, dead code) merged into a single `sequence(cacheControl, csp)` entry point, ensuring cache-control headers are enforced on all routes

## Test plan

- [x] Verify `GET /api/project-proxy?path=/api/method/../../api/auth/admin` returns 403
- [x] Verify normal proxied requests (`/api/method/foo`) still work
- [x] Confirm `Cache-Control: no-store` is set on API responses in production (Cloudflare)
- [x] Confirm `Cache-Control: public, max-age=600` is set on GET page responses
- [x] Confirm CSP nonce header still present on HTML responses