### PR TITLE
fix(security): allow CharityStack origins in CSP for donate-2 page

### DIFF
--- a/src/middleware/csp.ts
+++ b/src/middleware/csp.ts
@@ -24,8 +24,8 @@ export const csp = defineMiddleware(async (context, next) => {
     `style-src 'nonce-${nonce}' 'self' https://fonts.googleapis.com https://secure.qgiv.com`,
     "font-src 'self' https://fonts.gstatic.com https://gallery.eo.page",
     "img-src 'self' data: https:",
-    "connect-src 'self' https://plausible.io https://pal-chat.net https://eomail4.com https://www.google.com",
-    "frame-src https://secure.qgiv.com https://calendly.com https://www.youtube.com https://www.youtube-nocookie.com https://www.google.com https://validaid.org",
+    "connect-src 'self' https://plausible.io https://pal-chat.net https://eomail4.com https://www.google.com https://1k0gztb8b2.execute-api.us-east-2.amazonaws.com https://www.charitystack.com https://www.donation.charitystack.com",
+    "frame-src https://secure.qgiv.com https://calendly.com https://www.youtube.com https://www.youtube-nocookie.com https://www.google.com https://validaid.org https://www.charitystack.com",
     "object-src 'none'",
     "base-uri 'self'",
   ].join("; ");


### PR DESCRIPTION
## Summary

- Adds `https://1k0gztb8b2.execute-api.us-east-2.amazonaws.com` to `connect-src` (CharityStack elements-config API)
- Adds `https://www.charitystack.com` and `https://www.donation.charitystack.com` to `connect-src` (checkout pre-connections)
- Adds `https://www.charitystack.com` to `frame-src` (checkout iframe)

Fixes CSP violations on `/donate-2` that were blocking the CharityStack donation widget from fetching its config and rendering the checkout iframe.

## Note

The Cloudflare email-decode script (`cdn-cgi/scripts/.../email-decode.min.js`) is still blocked because `strict-dynamic` disables host allowlisting — that script is injected by the CF proxy after the Worker's HTMLRewriter runs and never receives a nonce. Fix: disable **Email Obfuscation** in the Cloudflare dashboard (Speed → Optimization → Content Optimization).

## Test plan

- [ ] Visit `/donate-2` and confirm no CSP errors for CharityStack in the browser console
- [ ] Confirm the donation widget loads and the checkout iframe renders