### PR TITLE
feat(membership): replace dues calculator with income slider

### DIFF
--- a/src/components/MembershipCalculator.tsx
+++ b/src/components/MembershipCalculator.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Box, Slider, Typography, Select, MenuItem, FormControl } from "@mui/material";
+import { Box, Slider, Typography, Select, MenuItem, FormControl, FormLabel } from "@mui/material";
 
 const CURRENCIES = [
   { code: "USD", symbol: "$", name: "US Dollar", usdRate: 1 },
@@ -31,92 +31,113 @@ export default function MembershipCalculator() {
   const usdSuggested = Math.round(suggested * currencyData.usdRate);
 
   return (
-    <Box sx={{ maxWidth: 600, mx: "auto", mb: 4 }}>
-      <Box
-        sx={{
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "space-between",
-          mb: 3,
-          gap: 2,
-          flexWrap: "wrap",
-        }}
+    <Box
+      sx={{
+        maxWidth: 600,
+        mx: "auto",
+        borderRadius: 2,
+        border: "1px solid #e5e7eb",
+        backgroundColor: "white",
+        p: 3,
+        mb: 4,
+      }}
+    >
+      <Typography
+        variant="body1"
+        component="h2"
+        sx={{ fontWeight: "bold", color: "#1f2937", mb: 2.5, fontSize: "0.95rem" }}
       >
-        <Typography sx={{ fontSize: "0.9rem", color: "#6b7280" }}>
-          Monthly income
-        </Typography>
-        <FormControl size="small">
+        Calculate Your Suggested Contribution
+      </Typography>
+
+      {/* Currency */}
+      <Box sx={{ mb: 2.5 }}>
+        <FormLabel sx={{ display: "block", mb: 1, fontWeight: 600, color: "#1f2937", fontSize: "0.875rem" }}>
+          Currency
+        </FormLabel>
+        <FormControl size="small" fullWidth>
           <Select
             value={currency}
             onChange={(e) => setCurrency(e.target.value)}
             sx={{
-              fontSize: "0.85rem",
-              color: "#374151",
-              "& .MuiOutlinedInput-notchedOutline": { borderColor: "#e5e7eb" },
-              "&:hover .MuiOutlinedInput-notchedOutline": { borderColor: "#d1d5db" },
-              "&.Mui-focused .MuiOutlinedInput-notchedOutline": { borderColor: "#9ca3af" },
+              backgroundColor: "white",
+              fontSize: "0.875rem",
+              "& .MuiOutlinedInput-notchedOutline": { borderColor: "#d1d5db" },
+              "&:hover .MuiOutlinedInput-notchedOutline": { borderColor: "#9ca3af" },
+              "&.Mui-focused .MuiOutlinedInput-notchedOutline": { borderColor: "#6b7280" },
             }}
           >
             {CURRENCIES.map((c) => (
-              <MenuItem key={c.code} value={c.code} sx={{ fontSize: "0.85rem" }}>
-                {c.symbol} {c.code}
+              <MenuItem key={c.code} value={c.code} sx={{ fontSize: "0.875rem" }}>
+                {c.symbol} {c.name} ({c.code})
               </MenuItem>
             ))}
           </Select>
         </FormControl>
       </Box>
 
-      <Box sx={{ px: 0.5 }}>
-        <Slider
-          value={income}
-          min={MIN_INCOME}
-          max={MAX_INCOME}
-          step={STEP}
-          onChange={(_, val) => setIncome(val as number)}
-          sx={{
-            color: "#9ca3af",
-            height: 4,
-            "& .MuiSlider-thumb": {
-              width: 20,
-              height: 20,
-              backgroundColor: "#fff",
-              border: "none",
-              boxShadow: "0 1px 4px rgba(0,0,0,0.25)",
-              "&:hover, &.Mui-focusVisible": { boxShadow: "0 1px 6px rgba(0,0,0,0.3)" },
-            },
-            "& .MuiSlider-track": { height: 4, border: "none", color: "#6b7280" },
-            "& .MuiSlider-rail": { height: 4, color: "#e5e7eb" },
-          }}
-        />
-      </Box>
-
-      <Box sx={{ display: "flex", justifyContent: "space-between", mt: 1, mb: 3 }}>
-        <Typography sx={{ fontSize: "0.8rem", color: "#9ca3af" }}>
-          {currencyData.symbol}0
-        </Typography>
-        <Typography sx={{ fontSize: "0.95rem", color: "#374151", fontWeight: 500 }}>
-          {currencyData.symbol}{income.toLocaleString()}
-          {income === MAX_INCOME && "+"}
-        </Typography>
-        <Typography sx={{ fontSize: "0.8rem", color: "#9ca3af" }}>
-          {currencyData.symbol}{MAX_INCOME.toLocaleString()}+
-        </Typography>
-      </Box>
-
-      {income > 0 && (
-        <Box sx={{ borderTop: "1px solid #f3f4f6", pt: 2 }}>
-          <Typography sx={{ fontSize: "0.9rem", color: "#6b7280", mb: 0.5 }}>
-            Suggested monthly contribution
+      {/* Slider */}
+      <Box sx={{ mb: 1 }}>
+        <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", mb: 1 }}>
+          <FormLabel sx={{ fontWeight: 600, color: "#1f2937", fontSize: "0.875rem" }}>
+            Monthly Income
+          </FormLabel>
+          <Typography sx={{ fontSize: "1rem", fontWeight: 600, color: "#374151" }}>
+            {currencyData.symbol}{income.toLocaleString()}{income === MAX_INCOME ? "+" : ""}
           </Typography>
-          <Typography sx={{ fontSize: "1.5rem", fontWeight: 600, color: "#168039" }}>
+        </Box>
+        <Box sx={{ px: 0.5 }}>
+          <Slider
+            value={income}
+            min={MIN_INCOME}
+            max={MAX_INCOME}
+            step={STEP}
+            onChange={(_, val) => setIncome(val as number)}
+            sx={{
+              color: "#9ca3af",
+              height: 4,
+              "& .MuiSlider-thumb": {
+                width: 20,
+                height: 20,
+                backgroundColor: "#fff",
+                border: "none",
+                boxShadow: "0 1px 4px rgba(0,0,0,0.25)",
+                "&:hover, &.Mui-focusVisible": { boxShadow: "0 1px 6px rgba(0,0,0,0.35)" },
+              },
+              "& .MuiSlider-track": { height: 4, border: "none", color: "#6b7280" },
+              "& .MuiSlider-rail": { height: 4, color: "#e5e7eb" },
+            }}
+          />
+        </Box>
+        <Box sx={{ display: "flex", justifyContent: "space-between" }}>
+          <Typography sx={{ fontSize: "0.75rem", color: "#9ca3af" }}>{currencyData.symbol}0</Typography>
+          <Typography sx={{ fontSize: "0.75rem", color: "#9ca3af" }}>{currencyData.symbol}{MAX_INCOME.toLocaleString()}+</Typography>
+        </Box>
+      </Box>
+
+      {/* Result */}
+      {income > 0 && (
+        <Box
+          sx={{
+            mt: 2.5,
+            p: 2,
+            backgroundColor: "#f0fdf4",
+            borderRadius: 2,
+            border: "1px solid #bbf7d0",
+          }}
+        >
+          <Typography sx={{ fontWeight: 600, color: "#166534", mb: 0.5, fontSize: "0.875rem" }}>
+            Suggested Monthly Contribution
+          </Typography>
+          <Typography sx={{ fontSize: "1.75rem", fontWeight: "bold", color: "#168039" }}>
             {currencyData.symbol}{suggested.toFixed(2)}
             {!isUSD && (
-              <Typography component="span" sx={{ fontSize: "0.95rem", color: "#9ca3af", fontWeight: 400, ml: 1 }}>
+              <Typography component="span" sx={{ fontWeight: 400, color: "#6b7280", fontSize: "1rem", ml: 1 }}>
                 (~${usdSuggested})
               </Typography>
             )}
           </Typography>
-          <Typography sx={{ fontSize: "0.8rem", color: "#9ca3af", mt: 0.5 }}>
+          <Typography sx={{ fontSize: "0.8rem", color: "#4b5563", mt: 0.5, fontStyle: "italic" }}>
             ≈ one hour of your time. Contribute what feels right to you.
           </Typography>
         </Box>

--- a/src/components/MembershipCalculator.tsx
+++ b/src/components/MembershipCalculator.tsx
@@ -1,5 +1,16 @@
 import { useState } from "react";
-import { Box, Slider, Typography, Select, MenuItem, FormControl, FormLabel, RadioGroup, FormControlLabel, Radio } from "@mui/material";
+import {
+  Box,
+  Slider,
+  FormControl,
+  FormLabel,
+  RadioGroup,
+  FormControlLabel,
+  Radio,
+  Typography,
+  Select,
+  MenuItem,
+} from "@mui/material";
 
 const CURRENCIES = [
   { code: "USD", symbol: "$", name: "US Dollar", usdRate: 1 },
@@ -16,33 +27,41 @@ const CURRENCIES = [
   { code: "ZAR", symbol: "R", name: "South African Rand", usdRate: 0.055 },
 ];
 
-const MIN_INCOME = 0;
 const MAX_MONTHLY = 20000;
 const MAX_ANNUAL = 240000;
-const STEP_MONTHLY = 100;
-const STEP_ANNUAL = 1000;
-const DEFAULT_MONTHLY = 5000;
-const DEFAULT_ANNUAL = 60000;
 
 export default function MembershipCalculator() {
-  const [incomeType, setIncomeType] = useState<"monthly" | "annual">("monthly");
-  const [income, setIncome] = useState<number>(DEFAULT_MONTHLY);
+  const [incomeType, setIncomeType] = useState<"annual" | "monthly">("monthly");
+  const [income, setIncome] = useState<number>(5000);
   const [currency, setCurrency] = useState<string>("USD");
 
   const max = incomeType === "monthly" ? MAX_MONTHLY : MAX_ANNUAL;
-  const step = incomeType === "monthly" ? STEP_MONTHLY : STEP_ANNUAL;
+  const step = incomeType === "monthly" ? 100 : 1000;
+
+  const handleIncomeTypeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newType = e.target.value as "annual" | "monthly";
+    setIncomeType(newType);
+    setIncome(newType === "monthly" ? 5000 : 60000);
+  };
+
+  const handleCurrencyChange = (e: any) => {
+    setCurrency(e.target.value);
+  };
 
   const currencyData = CURRENCIES.find((c) => c.code === currency) || CURRENCIES[0];
-  const monthlyIncome = incomeType === "monthly" ? income : income / 12;
-  const suggested = Math.round((monthlyIncome / 167) * 100) / 100;
-  const annualSuggested = Math.round(suggested * 12 * 100) / 100;
   const isUSD = currency === "USD";
-  const usdSuggested = Math.round(suggested * currencyData.usdRate);
-  const usdAnnualSuggested = Math.round(annualSuggested * currencyData.usdRate);
+  const monthlyIncome = incomeType === "monthly" ? income : income / 12;
+  const suggestedAmount = Math.round((monthlyIncome / 167) * 100) / 100;
+  const usdMonthly = Math.round(suggestedAmount * currencyData.usdRate);
+  const annualAmount = Math.round(suggestedAmount * 12 * 100) / 100;
+  const usdAnnual = Math.round(annualAmount * currencyData.usdRate);
 
-  const handleIncomeTypeChange = (newType: "monthly" | "annual") => {
-    setIncomeType(newType);
-    setIncome(newType === "monthly" ? DEFAULT_MONTHLY : DEFAULT_ANNUAL);
+  const resultBoxSx = {
+    flex: 1,
+    p: 2,
+    backgroundColor: "#f0fdf4",
+    borderRadius: 2,
+    border: "2px solid #168039",
   };
 
   return (
@@ -51,82 +70,85 @@ export default function MembershipCalculator() {
         maxWidth: 600,
         mx: "auto",
         borderRadius: 2,
-        border: "1px solid #e5e7eb",
+        border: "2px solid #168039",
         backgroundColor: "white",
-        p: 3,
+        p: 2,
         mb: 4,
       }}
     >
       <Typography
         variant="body1"
         component="h2"
-        sx={{ fontWeight: "bold", color: "#1f2937", mb: 2.5, fontSize: "0.95rem" }}
+        sx={{ fontWeight: "bold", color: "#1f2937", mb: 1.5, fontSize: "0.95rem" }}
       >
         Calculate Your Suggested Contribution
       </Typography>
 
-      {/* Income Period */}
-      <Box sx={{ mb: 2 }}>
-        <FormLabel component="legend" sx={{ display: "block", mb: 1, fontWeight: 600, color: "#1f2937", fontSize: "0.875rem" }}>
-          Income Period
-        </FormLabel>
-        <FormControl component="fieldset">
-          <RadioGroup
-            row
-            value={incomeType}
-            onChange={(e) => handleIncomeTypeChange(e.target.value as "monthly" | "annual")}
-            sx={{
-              gap: 1,
-              "& .MuiFormControlLabel-label": { fontSize: "0.875rem", color: "#374151" },
-              "& .MuiRadio-root": { color: "#9ca3af", "&.Mui-checked": { color: "#168039" } },
-            }}
-          >
-            <FormControlLabel value="monthly" control={<Radio size="small" />} label="Monthly Income" />
-            <FormControlLabel value="annual" control={<Radio size="small" />} label="Annual Income" />
-          </RadioGroup>
-        </FormControl>
-      </Box>
-
       {/* Currency */}
-      <Box sx={{ mb: 2.5 }}>
-        <FormLabel sx={{ display: "block", mb: 1, fontWeight: 600, color: "#1f2937", fontSize: "0.875rem" }}>
+      <Box sx={{ mb: 1.5 }}>
+        <FormLabel sx={{ display: "block", mb: 1, fontWeight: 600, color: "#1f2937", fontSize: "0.95rem" }}>
           Currency
         </FormLabel>
-        <FormControl size="small" fullWidth>
+        <FormControl fullWidth>
           <Select
             value={currency}
-            onChange={(e) => setCurrency(e.target.value)}
+            onChange={handleCurrencyChange}
+            displayEmpty
             sx={{
               backgroundColor: "white",
-              fontSize: "0.875rem",
               "& .MuiOutlinedInput-notchedOutline": { borderColor: "#d1d5db" },
               "&:hover .MuiOutlinedInput-notchedOutline": { borderColor: "#9ca3af" },
-              "&.Mui-focused .MuiOutlinedInput-notchedOutline": { borderColor: "#6b7280" },
+              "&.Mui-focused .MuiOutlinedInput-notchedOutline": { borderColor: "#168039" },
             }}
           >
-            {CURRENCIES.map((c) => (
-              <MenuItem key={c.code} value={c.code} sx={{ fontSize: "0.875rem" }}>
-                {c.symbol} {c.name} ({c.code})
+            {CURRENCIES.map((curr) => (
+              <MenuItem key={curr.code} value={curr.code}>
+                {curr.symbol} {curr.name} ({curr.code})
               </MenuItem>
             ))}
           </Select>
         </FormControl>
       </Box>
 
-      {/* Slider */}
-      <Box sx={{ mb: 1 }}>
+      {/* Income Period */}
+      <Box sx={{ mb: 1.5 }}>
+        <FormLabel
+          component="legend"
+          sx={{ display: "block", mb: 1, fontWeight: 600, color: "#1f2937", fontSize: "0.95rem" }}
+        >
+          Income Period
+        </FormLabel>
+        <FormControl component="fieldset">
+          <RadioGroup
+            row
+            value={incomeType}
+            onChange={handleIncomeTypeChange}
+            sx={{
+              gap: 1,
+              "& .MuiFormControlLabel-label": { fontSize: "0.95rem", color: "#374151" },
+              "& .MuiRadio-root": { color: "#9ca3af", "&.Mui-checked": { color: "#168039" } },
+            }}
+          >
+            <FormControlLabel value="annual" control={<Radio />} label="Annual Income" />
+            <FormControlLabel value="monthly" control={<Radio />} label="Monthly Income" />
+          </RadioGroup>
+        </FormControl>
+      </Box>
+
+      {/* Income Slider */}
+      <Box sx={{ mb: 1.5 }}>
         <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", mb: 1 }}>
-          <FormLabel sx={{ fontWeight: 600, color: "#1f2937", fontSize: "0.875rem" }}>
+          <FormLabel sx={{ fontWeight: 600, color: "#1f2937", fontSize: "0.95rem" }}>
             {incomeType === "monthly" ? "Monthly" : "Annual"} Income
           </FormLabel>
-          <Typography sx={{ fontSize: "1rem", fontWeight: 600, color: "#374151" }}>
+          <Typography sx={{ fontSize: "0.95rem", fontWeight: 600, color: "#374151" }}>
             {currencyData.symbol}{income.toLocaleString()}{income === max ? "+" : ""}
           </Typography>
         </Box>
         <Box sx={{ px: 0.5 }}>
           <Slider
             value={income}
-            min={MIN_INCOME}
+            min={0}
             max={max}
             step={step}
             onChange={(_, val) => setIncome(val as number)}
@@ -152,33 +174,35 @@ export default function MembershipCalculator() {
         </Box>
       </Box>
 
-      {/* Result */}
+      {/* Results */}
       {income > 0 && (
-        <Box sx={{ mt: 2.5, display: "flex", gap: 2, flexWrap: "wrap" }}>
-          <Box sx={{ flex: 1, p: 2, backgroundColor: "#f0fdf4", borderRadius: 2, border: "1px solid #bbf7d0" }}>
-            <Typography sx={{ fontWeight: 600, color: "#166534", mb: 0.5, fontSize: "0.875rem" }}>
-              Suggested Monthly Contribution
+        <Box sx={{ mt: 1.5, display: "flex", gap: 2, flexWrap: "wrap" }}>
+          {/* Monthly */}
+          <Box sx={resultBoxSx}>
+            <Typography variant="h6" sx={{ fontWeight: 600, color: "#166534", mb: 0.5, fontSize: "1rem" }}>
+              Suggested Monthly Contribution:
             </Typography>
-            <Typography sx={{ fontSize: "1.75rem", fontWeight: "bold", color: "#168039" }}>
-              {currencyData.symbol}{suggested.toFixed(2)}
+            <Typography variant="h4" sx={{ fontWeight: "bold", color: "#168039", fontSize: "1.75rem" }}>
+              {currencyData.symbol}{suggestedAmount.toFixed(2)}
               {!isUSD && (
                 <Typography component="span" sx={{ fontWeight: 400, color: "#6b7280", fontSize: "1rem", ml: 1 }}>
-                  (~${usdSuggested})
+                  (~${usdMonthly})
                 </Typography>
               )}
             </Typography>
           </Box>
 
+          {/* Annual — only when user selected annual income */}
           {incomeType === "annual" && (
-            <Box sx={{ flex: 1, p: 2, backgroundColor: "#f0fdf4", borderRadius: 2, border: "1px solid #bbf7d0" }}>
-              <Typography sx={{ fontWeight: 600, color: "#166534", mb: 0.5, fontSize: "0.875rem" }}>
-                Suggested Annual Contribution
+            <Box sx={resultBoxSx}>
+              <Typography variant="h6" sx={{ fontWeight: 600, color: "#166534", mb: 0.5, fontSize: "1rem" }}>
+                Suggested Annual Contribution:
               </Typography>
-              <Typography sx={{ fontSize: "1.75rem", fontWeight: "bold", color: "#168039" }}>
-                {currencyData.symbol}{annualSuggested.toFixed(2)}
+              <Typography variant="h4" sx={{ fontWeight: "bold", color: "#168039", fontSize: "1.75rem" }}>
+                {currencyData.symbol}{annualAmount.toFixed(2)}
                 {!isUSD && (
                   <Typography component="span" sx={{ fontWeight: 400, color: "#6b7280", fontSize: "1rem", ml: 1 }}>
-                    (~${usdAnnualSuggested})
+                    (~${usdAnnual})
                   </Typography>
                 )}
               </Typography>
@@ -188,8 +212,9 @@ export default function MembershipCalculator() {
       )}
 
       {income > 0 && (
-        <Typography sx={{ fontSize: "0.8rem", color: "#4b5563", mt: 1.5, fontStyle: "italic" }}>
-          ≈ one hour of your time. Contribute what feels right to you.
+        <Typography variant="body2" sx={{ mt: 1, color: "#4b5563", fontStyle: "italic", fontSize: "0.875rem" }}>
+          This is a suggested amount based on your income. Please contribute what feels meaningful to you.
+          {!isUSD && " USD equivalent is approximate."}
         </Typography>
       )}
     </Box>

--- a/src/components/MembershipCalculator.tsx
+++ b/src/components/MembershipCalculator.tsx
@@ -1,16 +1,5 @@
 import { useState } from "react";
-import {
-  Box,
-  TextField,
-  FormControl,
-  FormLabel,
-  RadioGroup,
-  FormControlLabel,
-  Radio,
-  Typography,
-  Select,
-  MenuItem,
-} from "@mui/material";
+import { Box, Slider, Typography, Select, MenuItem, FormControl } from "@mui/material";
 
 const CURRENCIES = [
   { code: "USD", symbol: "$", name: "US Dollar", usdRate: 1 },
@@ -27,193 +16,110 @@ const CURRENCIES = [
   { code: "ZAR", symbol: "R", name: "South African Rand", usdRate: 0.055 },
 ];
 
+const MIN_INCOME = 0;
+const MAX_INCOME = 20000;
+const STEP = 100;
+const DEFAULT_INCOME = 5000;
+
 export default function MembershipCalculator() {
-  const [incomeType, setIncomeType] = useState<"annual" | "monthly">("monthly");
-  const [income, setIncome] = useState<string>("");
+  const [income, setIncome] = useState<number>(DEFAULT_INCOME);
   const [currency, setCurrency] = useState<string>("USD");
-  const [suggestedAmount, setSuggestedAmount] = useState<number | null>(null);
 
-  const getCurrencyData = () => CURRENCIES.find((c) => c.code === currency) || CURRENCIES[0];
-
-  const calculateSuggestion = (value: string, type: "annual" | "monthly" = incomeType) => {
-    const numericValue = parseFloat(value);
-    if (isNaN(numericValue) || numericValue <= 0) {
-      setSuggestedAmount(null);
-      return;
-    }
-    const suggestion = type === "annual" ? numericValue / 2000 : numericValue / 167;
-    setSuggestedAmount(Math.round(suggestion * 100) / 100);
-  };
-
-  const handleIncomeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value;
-    setIncome(value);
-    calculateSuggestion(value);
-  };
-
-  const handleIncomeTypeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const newType = e.target.value as "annual" | "monthly";
-    setIncomeType(newType);
-    if (income) calculateSuggestion(income, newType);
-  };
-
-  const handleCurrencyChange = (e: any) => {
-    setCurrency(e.target.value);
-  };
-
-  const currencyData = getCurrencyData();
+  const currencyData = CURRENCIES.find((c) => c.code === currency) || CURRENCIES[0];
+  const suggested = Math.round((income / 167) * 100) / 100;
   const isUSD = currency === "USD";
-  const usdMonthly = suggestedAmount !== null ? Math.round(suggestedAmount * currencyData.usdRate) : null;
-  const annualAmount = suggestedAmount !== null ? Math.round(suggestedAmount * 12 * 100) / 100 : null;
-  const usdAnnual = annualAmount !== null ? Math.round(annualAmount * currencyData.usdRate) : null;
-
-  const resultBoxSx = {
-    flex: 1,
-    p: 2,
-    backgroundColor: "#f0fdf4",
-    borderRadius: 2,
-    border: "2px solid #168039",
-  };
+  const usdSuggested = Math.round(suggested * currencyData.usdRate);
 
   return (
-    <Box
-      sx={{
-        maxWidth: 600,
-        mx: "auto",
-        borderRadius: 2,
-        border: "2px solid #168039",
-        backgroundColor: "white",
-        p: 2,
-        mb: 4,
-      }}
-    >
-      <Typography
-        variant="body1"
-        component="h2"
-        sx={{ fontWeight: "bold", color: "#1f2937", mb: 1.5, fontSize: "0.95rem" }}
+    <Box sx={{ maxWidth: 600, mx: "auto", mb: 4 }}>
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          mb: 3,
+          gap: 2,
+          flexWrap: "wrap",
+        }}
       >
-        Calculate Your Suggested Contribution
-      </Typography>
-
-      {/* Currency */}
-      <Box sx={{ mb: 1.5 }}>
-        <FormLabel sx={{ display: "block", mb: 1, fontWeight: 600, color: "#1f2937", fontSize: "0.95rem" }}>
-          Currency
-        </FormLabel>
-        <FormControl fullWidth>
+        <Typography sx={{ fontSize: "0.9rem", color: "#6b7280" }}>
+          Monthly income
+        </Typography>
+        <FormControl size="small">
           <Select
             value={currency}
-            onChange={handleCurrencyChange}
-            displayEmpty
+            onChange={(e) => setCurrency(e.target.value)}
             sx={{
-              backgroundColor: "white",
-              "& .MuiOutlinedInput-notchedOutline": { borderColor: "#d1d5db" },
-              "&:hover .MuiOutlinedInput-notchedOutline": { borderColor: "#9ca3af" },
-              "&.Mui-focused .MuiOutlinedInput-notchedOutline": { borderColor: "#168039" },
+              fontSize: "0.85rem",
+              color: "#374151",
+              "& .MuiOutlinedInput-notchedOutline": { borderColor: "#e5e7eb" },
+              "&:hover .MuiOutlinedInput-notchedOutline": { borderColor: "#d1d5db" },
+              "&.Mui-focused .MuiOutlinedInput-notchedOutline": { borderColor: "#9ca3af" },
             }}
           >
-            {CURRENCIES.map((curr) => (
-              <MenuItem key={curr.code} value={curr.code}>
-                {curr.symbol} {curr.name} ({curr.code})
+            {CURRENCIES.map((c) => (
+              <MenuItem key={c.code} value={c.code} sx={{ fontSize: "0.85rem" }}>
+                {c.symbol} {c.code}
               </MenuItem>
             ))}
           </Select>
         </FormControl>
       </Box>
 
-      {/* Income Period */}
-      <Box sx={{ mb: 1.5 }}>
-        <FormLabel
-          component="legend"
-          sx={{ display: "block", mb: 1, fontWeight: 600, color: "#1f2937", fontSize: "0.95rem" }}
-        >
-          Income Period
-        </FormLabel>
-        <FormControl component="fieldset">
-          <RadioGroup
-            row
-            value={incomeType}
-            onChange={handleIncomeTypeChange}
-            sx={{
-              gap: 1,
-              "& .MuiFormControlLabel-label": { fontSize: "0.95rem", color: "#374151" },
-              "& .MuiRadio-root": { color: "#9ca3af", "&.Mui-checked": { color: "#168039" } },
-            }}
-          >
-            <FormControlLabel value="annual" control={<Radio />} label="Annual Income" />
-            <FormControlLabel value="monthly" control={<Radio />} label="Monthly Income" />
-          </RadioGroup>
-        </FormControl>
-      </Box>
-
-      {/* Income Input */}
-      <Box sx={{ mb: 1.5 }}>
-        <TextField
-          fullWidth
-          type="number"
+      <Box sx={{ px: 0.5 }}>
+        <Slider
           value={income}
-          onChange={handleIncomeChange}
-          placeholder={incomeType === "annual" ? "e.g., 60000" : "e.g., 5000"}
+          min={MIN_INCOME}
+          max={MAX_INCOME}
+          step={STEP}
+          onChange={(_, val) => setIncome(val as number)}
           sx={{
-            "& .MuiOutlinedInput-root": {
-              backgroundColor: "white",
-              "& fieldset": { borderColor: "#d1d5db" },
-              "&:hover fieldset": { borderColor: "#9ca3af" },
-              "&.Mui-focused fieldset": { borderColor: "#168039" },
+            color: "#9ca3af",
+            height: 4,
+            "& .MuiSlider-thumb": {
+              width: 20,
+              height: 20,
+              backgroundColor: "#fff",
+              border: "none",
+              boxShadow: "0 1px 4px rgba(0,0,0,0.25)",
+              "&:hover, &.Mui-focusVisible": { boxShadow: "0 1px 6px rgba(0,0,0,0.3)" },
             },
+            "& .MuiSlider-track": { height: 4, border: "none", color: "#6b7280" },
+            "& .MuiSlider-rail": { height: 4, color: "#e5e7eb" },
           }}
-          InputProps={{ inputProps: { min: 0, step: "any" } }}
         />
       </Box>
 
-      {/* Results */}
-      {suggestedAmount !== null && (
-        <Box sx={{ mt: 1.5, display: "flex", gap: 2, flexWrap: "wrap" }}>
-          {/* Monthly */}
-          <Box sx={resultBoxSx}>
-            <Typography variant="h6" sx={{ fontWeight: 600, color: "#166534", mb: 0.5, fontSize: "1rem" }}>
-              Suggested Monthly Contribution:
-            </Typography>
-            <Typography variant="h4" sx={{ fontWeight: "bold", color: "#168039", fontSize: "1.75rem" }}>
-              {currencyData.symbol}{suggestedAmount.toFixed(2)}
-              {!isUSD && usdMonthly !== null && (
-                <Typography component="span" sx={{ fontWeight: 400, color: "#6b7280", fontSize: "1rem", ml: 1 }}>
-                  (~${usdMonthly})
-                </Typography>
-              )}
-            </Typography>
-          </Box>
+      <Box sx={{ display: "flex", justifyContent: "space-between", mt: 1, mb: 3 }}>
+        <Typography sx={{ fontSize: "0.8rem", color: "#9ca3af" }}>
+          {currencyData.symbol}0
+        </Typography>
+        <Typography sx={{ fontSize: "0.95rem", color: "#374151", fontWeight: 500 }}>
+          {currencyData.symbol}{income.toLocaleString()}
+          {income === MAX_INCOME && "+"}
+        </Typography>
+        <Typography sx={{ fontSize: "0.8rem", color: "#9ca3af" }}>
+          {currencyData.symbol}{MAX_INCOME.toLocaleString()}+
+        </Typography>
+      </Box>
 
-          {/* Annual — only when user selected annual income */}
-          {incomeType === "annual" && annualAmount !== null && (
-            <Box sx={resultBoxSx}>
-              <Typography variant="h6" sx={{ fontWeight: 600, color: "#166534", mb: 0.5, fontSize: "1rem" }}>
-                Suggested Annual Contribution:
+      {income > 0 && (
+        <Box sx={{ borderTop: "1px solid #f3f4f6", pt: 2 }}>
+          <Typography sx={{ fontSize: "0.9rem", color: "#6b7280", mb: 0.5 }}>
+            Suggested monthly contribution
+          </Typography>
+          <Typography sx={{ fontSize: "1.5rem", fontWeight: 600, color: "#168039" }}>
+            {currencyData.symbol}{suggested.toFixed(2)}
+            {!isUSD && (
+              <Typography component="span" sx={{ fontSize: "0.95rem", color: "#9ca3af", fontWeight: 400, ml: 1 }}>
+                (~${usdSuggested})
               </Typography>
-              <Typography variant="h4" sx={{ fontWeight: "bold", color: "#168039", fontSize: "1.75rem" }}>
-                {currencyData.symbol}{annualAmount.toFixed(2)}
-                {!isUSD && usdAnnual !== null && (
-                  <Typography component="span" sx={{ fontWeight: 400, color: "#6b7280", fontSize: "1rem", ml: 1 }}>
-                    (~${usdAnnual})
-                  </Typography>
-                )}
-              </Typography>
-            </Box>
-          )}
+            )}
+          </Typography>
+          <Typography sx={{ fontSize: "0.8rem", color: "#9ca3af", mt: 0.5 }}>
+            ≈ one hour of your time. Contribute what feels right to you.
+          </Typography>
         </Box>
-      )}
-
-      {suggestedAmount !== null && (
-        <Typography variant="body2" sx={{ mt: 1, color: "#4b5563", fontStyle: "italic", fontSize: "0.875rem" }}>
-          This is a suggested amount based on your income. Please contribute what feels meaningful to you.
-          {!isUSD && " USD equivalent is approximate."}
-        </Typography>
-      )}
-
-      {income && suggestedAmount === null && (
-        <Typography variant="body2" sx={{ mt: 1.5, color: "#dc2626", fontSize: "0.875rem" }}>
-          Please enter a valid positive number
-        </Typography>
       )}
     </Box>
   );

--- a/src/components/MembershipCalculator.tsx
+++ b/src/components/MembershipCalculator.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import {
   Box,
-  Slider,
+  TextField,
   FormControl,
   RadioGroup,
   FormControlLabel,
@@ -26,9 +26,6 @@ const CURRENCIES = [
   { code: "ZAR", symbol: "R", name: "South African Rand", usdRate: 0.055 },
 ];
 
-const MAX_MONTHLY = 20000;
-const MAX_ANNUAL = 240000;
-
 const rowSx = {
   display: "flex",
   alignItems: "center",
@@ -46,21 +43,18 @@ const labelSx = {
 
 export default function MembershipCalculator() {
   const [incomeType, setIncomeType] = useState<"annual" | "monthly">("monthly");
-  const [income, setIncome] = useState<number>(5000);
+  const [income, setIncome] = useState<string>("");
   const [currency, setCurrency] = useState<string>("USD");
 
-  const max = incomeType === "monthly" ? MAX_MONTHLY : MAX_ANNUAL;
-  const step = incomeType === "monthly" ? 100 : 1000;
-
   const handleIncomeTypeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const newType = e.target.value as "annual" | "monthly";
-    setIncomeType(newType);
-    setIncome(newType === "monthly" ? 5000 : 60000);
+    setIncomeType(e.target.value as "annual" | "monthly");
   };
 
   const currencyData = CURRENCIES.find((c) => c.code === currency) || CURRENCIES[0];
   const isUSD = currency === "USD";
-  const monthlyIncome = incomeType === "monthly" ? income : income / 12;
+  const numericIncome = parseFloat(income);
+  const hasValidIncome = !isNaN(numericIncome) && numericIncome > 0;
+  const monthlyIncome = hasValidIncome ? (incomeType === "monthly" ? numericIncome : numericIncome / 12) : 0;
   const suggestedMonthly = Math.round((monthlyIncome / 167) * 100) / 100;
   const suggestedAnnual = Math.round(suggestedMonthly * 12 * 100) / 100;
 
@@ -122,39 +116,27 @@ export default function MembershipCalculator() {
             </RadioGroup>
           </FormControl>
         </Box>
-        <Box sx={{ flex: 1, display: "flex", alignItems: "center", gap: 1 }}>
-          <Box sx={{ flex: 1, px: 0.5 }}>
-            <Slider
-              value={income}
-              min={0}
-              max={max}
-              step={step}
-              onChange={(_, val) => setIncome(val as number)}
-              sx={{
-                color: "#9ca3af",
-                height: 4,
-                py: "10px",
-                "& .MuiSlider-thumb": {
-                  width: 18,
-                  height: 18,
-                  backgroundColor: "#fff",
-                  border: "none",
-                  boxShadow: "0 1px 4px rgba(0,0,0,0.25)",
-                  "&:hover, &.Mui-focusVisible": { boxShadow: "0 1px 6px rgba(0,0,0,0.35)" },
-                },
-                "& .MuiSlider-track": { height: 4, border: "none", color: "#6b7280" },
-                "& .MuiSlider-rail": { height: 4, color: "#e5e7eb" },
-              }}
-            />
-          </Box>
-          <Typography sx={{ fontSize: "0.875rem", fontWeight: 600, color: "#374151", whiteSpace: "nowrap", minWidth: 70, textAlign: "right" }}>
-            {currencyData.symbol}{income.toLocaleString()}{income === max ? "+" : ""}
-          </Typography>
-        </Box>
+        <TextField
+          size="small"
+          type="number"
+          value={income}
+          onChange={(e) => setIncome(e.target.value)}
+          placeholder={incomeType === "annual" ? "e.g. 60000" : "e.g. 5000"}
+          sx={{
+            flex: 1,
+            "& .MuiOutlinedInput-root": {
+              backgroundColor: "white",
+              "& fieldset": { borderColor: "#d1d5db" },
+              "&:hover fieldset": { borderColor: "#9ca3af" },
+              "&.Mui-focused fieldset": { borderColor: "#168039" },
+            },
+          }}
+          InputProps={{ inputProps: { min: 0, step: "any" } }}
+        />
       </Box>
 
       {/* Results row */}
-      {income > 0 && (
+      {hasValidIncome && (
         <Box
           sx={{
             display: "flex",

--- a/src/components/MembershipCalculator.tsx
+++ b/src/components/MembershipCalculator.tsx
@@ -3,7 +3,6 @@ import {
   Box,
   Slider,
   FormControl,
-  FormLabel,
   RadioGroup,
   FormControlLabel,
   Radio,
@@ -30,6 +29,21 @@ const CURRENCIES = [
 const MAX_MONTHLY = 20000;
 const MAX_ANNUAL = 240000;
 
+const rowSx = {
+  display: "flex",
+  alignItems: "center",
+  gap: 1.5,
+  mb: 1,
+};
+
+const labelSx = {
+  fontSize: "0.875rem",
+  fontWeight: 600,
+  color: "#1f2937",
+  whiteSpace: "nowrap",
+  minWidth: 110,
+};
+
 export default function MembershipCalculator() {
   const [incomeType, setIncomeType] = useState<"annual" | "monthly">("monthly");
   const [income, setIncome] = useState<number>(5000);
@@ -44,25 +58,11 @@ export default function MembershipCalculator() {
     setIncome(newType === "monthly" ? 5000 : 60000);
   };
 
-  const handleCurrencyChange = (e: any) => {
-    setCurrency(e.target.value);
-  };
-
   const currencyData = CURRENCIES.find((c) => c.code === currency) || CURRENCIES[0];
   const isUSD = currency === "USD";
   const monthlyIncome = incomeType === "monthly" ? income : income / 12;
-  const suggestedAmount = Math.round((monthlyIncome / 167) * 100) / 100;
-  const usdMonthly = Math.round(suggestedAmount * currencyData.usdRate);
-  const annualAmount = Math.round(suggestedAmount * 12 * 100) / 100;
-  const usdAnnual = Math.round(annualAmount * currencyData.usdRate);
-
-  const resultBoxSx = {
-    flex: 1,
-    p: 2,
-    backgroundColor: "#f0fdf4",
-    borderRadius: 2,
-    border: "2px solid #168039",
-  };
+  const suggestedMonthly = Math.round((monthlyIncome / 167) * 100) / 100;
+  const suggestedAnnual = Math.round(suggestedMonthly * 12 * 100) / 100;
 
   return (
     <Box
@@ -72,29 +72,19 @@ export default function MembershipCalculator() {
         borderRadius: 2,
         border: "2px solid #168039",
         backgroundColor: "white",
-        p: 2,
+        p: 1.5,
         mb: 4,
       }}
     >
-      <Typography
-        variant="body1"
-        component="h2"
-        sx={{ fontWeight: "bold", color: "#1f2937", mb: 1.5, fontSize: "0.95rem" }}
-      >
-        Calculate Your Suggested Contribution
-      </Typography>
-
-      {/* Currency */}
-      <Box sx={{ mb: 1.5 }}>
-        <FormLabel sx={{ display: "block", mb: 1, fontWeight: 600, color: "#1f2937", fontSize: "0.95rem" }}>
-          Currency
-        </FormLabel>
-        <FormControl fullWidth>
+      {/* Currency row */}
+      <Box sx={rowSx}>
+        <Typography sx={labelSx}>Currency</Typography>
+        <FormControl size="small" sx={{ flex: 1 }}>
           <Select
             value={currency}
-            onChange={handleCurrencyChange}
-            displayEmpty
+            onChange={(e) => setCurrency(e.target.value)}
             sx={{
+              fontSize: "0.875rem",
               backgroundColor: "white",
               "& .MuiOutlinedInput-notchedOutline": { borderColor: "#d1d5db" },
               "&:hover .MuiOutlinedInput-notchedOutline": { borderColor: "#9ca3af" },
@@ -102,7 +92,7 @@ export default function MembershipCalculator() {
             }}
           >
             {CURRENCIES.map((curr) => (
-              <MenuItem key={curr.code} value={curr.code}>
+              <MenuItem key={curr.code} value={curr.code} sx={{ fontSize: "0.875rem" }}>
                 {curr.symbol} {curr.name} ({curr.code})
               </MenuItem>
             ))}
@@ -110,112 +100,99 @@ export default function MembershipCalculator() {
         </FormControl>
       </Box>
 
-      {/* Income Period */}
-      <Box sx={{ mb: 1.5 }}>
-        <FormLabel
-          component="legend"
-          sx={{ display: "block", mb: 1, fontWeight: 600, color: "#1f2937", fontSize: "0.95rem" }}
-        >
-          Income Period
-        </FormLabel>
-        <FormControl component="fieldset">
-          <RadioGroup
-            row
-            value={incomeType}
-            onChange={handleIncomeTypeChange}
-            sx={{
-              gap: 1,
-              "& .MuiFormControlLabel-label": { fontSize: "0.95rem", color: "#374151" },
-              "& .MuiRadio-root": { color: "#9ca3af", "&.Mui-checked": { color: "#168039" } },
-            }}
-          >
-            <FormControlLabel value="annual" control={<Radio />} label="Annual Income" />
-            <FormControlLabel value="monthly" control={<Radio />} label="Monthly Income" />
-          </RadioGroup>
-        </FormControl>
-      </Box>
-
-      {/* Income Slider */}
-      <Box sx={{ mb: 1.5 }}>
-        <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", mb: 1 }}>
-          <FormLabel sx={{ fontWeight: 600, color: "#1f2937", fontSize: "0.95rem" }}>
-            {incomeType === "monthly" ? "Monthly" : "Annual"} Income
-          </FormLabel>
-          <Typography sx={{ fontSize: "0.95rem", fontWeight: 600, color: "#374151" }}>
+      {/* Income row */}
+      <Box sx={rowSx}>
+        <Box sx={{ minWidth: 110 }}>
+          <Typography sx={labelSx}>Income</Typography>
+          <FormControl component="fieldset">
+            <RadioGroup
+              row
+              value={incomeType}
+              onChange={handleIncomeTypeChange}
+              sx={{
+                flexWrap: "nowrap",
+                gap: 2,
+                "& .MuiFormControlLabel-label": { fontSize: "0.75rem", color: "#374151" },
+                "& .MuiFormControlLabel-root": { mr: 0 },
+                "& .MuiRadio-root": { p: 0.5, color: "#9ca3af", "&.Mui-checked": { color: "#168039" } },
+              }}
+            >
+              <FormControlLabel value="monthly" control={<Radio size="small" />} label="Monthly" />
+              <FormControlLabel value="annual" control={<Radio size="small" />} label="Annual" />
+            </RadioGroup>
+          </FormControl>
+        </Box>
+        <Box sx={{ flex: 1, display: "flex", alignItems: "center", gap: 1 }}>
+          <Box sx={{ flex: 1, px: 0.5 }}>
+            <Slider
+              value={income}
+              min={0}
+              max={max}
+              step={step}
+              onChange={(_, val) => setIncome(val as number)}
+              sx={{
+                color: "#9ca3af",
+                height: 4,
+                py: "10px",
+                "& .MuiSlider-thumb": {
+                  width: 18,
+                  height: 18,
+                  backgroundColor: "#fff",
+                  border: "none",
+                  boxShadow: "0 1px 4px rgba(0,0,0,0.25)",
+                  "&:hover, &.Mui-focusVisible": { boxShadow: "0 1px 6px rgba(0,0,0,0.35)" },
+                },
+                "& .MuiSlider-track": { height: 4, border: "none", color: "#6b7280" },
+                "& .MuiSlider-rail": { height: 4, color: "#e5e7eb" },
+              }}
+            />
+          </Box>
+          <Typography sx={{ fontSize: "0.875rem", fontWeight: 600, color: "#374151", whiteSpace: "nowrap", minWidth: 70, textAlign: "right" }}>
             {currencyData.symbol}{income.toLocaleString()}{income === max ? "+" : ""}
           </Typography>
         </Box>
-        <Box sx={{ px: 0.5 }}>
-          <Slider
-            value={income}
-            min={0}
-            max={max}
-            step={step}
-            onChange={(_, val) => setIncome(val as number)}
-            sx={{
-              color: "#9ca3af",
-              height: 4,
-              "& .MuiSlider-thumb": {
-                width: 20,
-                height: 20,
-                backgroundColor: "#fff",
-                border: "none",
-                boxShadow: "0 1px 4px rgba(0,0,0,0.25)",
-                "&:hover, &.Mui-focusVisible": { boxShadow: "0 1px 6px rgba(0,0,0,0.35)" },
-              },
-              "& .MuiSlider-track": { height: 4, border: "none", color: "#6b7280" },
-              "& .MuiSlider-rail": { height: 4, color: "#e5e7eb" },
-            }}
-          />
-        </Box>
-        <Box sx={{ display: "flex", justifyContent: "space-between" }}>
-          <Typography sx={{ fontSize: "0.75rem", color: "#9ca3af" }}>{currencyData.symbol}0</Typography>
-          <Typography sx={{ fontSize: "0.75rem", color: "#9ca3af" }}>{currencyData.symbol}{max.toLocaleString()}+</Typography>
-        </Box>
       </Box>
 
-      {/* Results */}
+      {/* Results row */}
       {income > 0 && (
-        <Box sx={{ mt: 1.5, display: "flex", gap: 2, flexWrap: "wrap" }}>
-          {/* Monthly */}
-          <Box sx={resultBoxSx}>
-            <Typography variant="h6" sx={{ fontWeight: 600, color: "#166534", mb: 0.5, fontSize: "1rem" }}>
-              Suggested Monthly Contribution:
+        <Box
+          sx={{
+            display: "flex",
+            gap: 1,
+            mt: 0.5,
+            p: 1.5,
+            backgroundColor: "#f0fdf4",
+            borderRadius: 1.5,
+            border: "2px solid #168039",
+          }}
+        >
+          <Box sx={{ flex: 1 }}>
+            <Typography sx={{ fontSize: "0.75rem", fontWeight: 600, color: "#166534", lineHeight: 1.3 }}>
+              Suggested Monthly Dues:
             </Typography>
-            <Typography variant="h4" sx={{ fontWeight: "bold", color: "#168039", fontSize: "1.75rem" }}>
-              {currencyData.symbol}{suggestedAmount.toFixed(2)}
-              {!isUSD && (
-                <Typography component="span" sx={{ fontWeight: 400, color: "#6b7280", fontSize: "1rem", ml: 1 }}>
-                  (~${usdMonthly})
-                </Typography>
-              )}
+            <Typography sx={{ fontSize: "1.4rem", fontWeight: "bold", color: "#168039", lineHeight: 1.2 }}>
+              {currencyData.symbol}{suggestedMonthly.toFixed(2)}
             </Typography>
+            {!isUSD && (
+              <Typography sx={{ fontSize: "0.7rem", color: "#6b7280" }}>
+                (~${Math.round(suggestedMonthly * currencyData.usdRate)} USD)
+              </Typography>
+            )}
           </Box>
-
-          {/* Annual — only when user selected annual income */}
-          {incomeType === "annual" && (
-            <Box sx={resultBoxSx}>
-              <Typography variant="h6" sx={{ fontWeight: 600, color: "#166534", mb: 0.5, fontSize: "1rem" }}>
-                Suggested Annual Contribution:
+          <Box sx={{ flex: 1 }}>
+            <Typography sx={{ fontSize: "0.75rem", fontWeight: 600, color: "#166534", lineHeight: 1.3 }}>
+              Suggested Annual Dues:
+            </Typography>
+            <Typography sx={{ fontSize: "1.4rem", fontWeight: "bold", color: "#168039", lineHeight: 1.2 }}>
+              {currencyData.symbol}{suggestedAnnual.toFixed(2)}
+            </Typography>
+            {!isUSD && (
+              <Typography sx={{ fontSize: "0.7rem", color: "#6b7280" }}>
+                (~${Math.round(suggestedAnnual * currencyData.usdRate)} USD)
               </Typography>
-              <Typography variant="h4" sx={{ fontWeight: "bold", color: "#168039", fontSize: "1.75rem" }}>
-                {currencyData.symbol}{annualAmount.toFixed(2)}
-                {!isUSD && (
-                  <Typography component="span" sx={{ fontWeight: 400, color: "#6b7280", fontSize: "1rem", ml: 1 }}>
-                    (~${usdAnnual})
-                  </Typography>
-                )}
-              </Typography>
-            </Box>
-          )}
+            )}
+          </Box>
         </Box>
-      )}
-
-      {income > 0 && (
-        <Typography variant="body2" sx={{ mt: 1, color: "#4b5563", fontStyle: "italic", fontSize: "0.875rem" }}>
-          This is a suggested amount based on your income. Please contribute what feels meaningful to you.
-          {!isUSD && " USD equivalent is approximate."}
-        </Typography>
       )}
     </Box>
   );

--- a/src/components/MembershipCalculator.tsx
+++ b/src/components/MembershipCalculator.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Box, Slider, Typography, Select, MenuItem, FormControl, FormLabel } from "@mui/material";
+import { Box, Slider, Typography, Select, MenuItem, FormControl, FormLabel, RadioGroup, FormControlLabel, Radio } from "@mui/material";
 
 const CURRENCIES = [
   { code: "USD", symbol: "$", name: "US Dollar", usdRate: 1 },
@@ -17,18 +17,33 @@ const CURRENCIES = [
 ];
 
 const MIN_INCOME = 0;
-const MAX_INCOME = 20000;
-const STEP = 100;
-const DEFAULT_INCOME = 5000;
+const MAX_MONTHLY = 20000;
+const MAX_ANNUAL = 240000;
+const STEP_MONTHLY = 100;
+const STEP_ANNUAL = 1000;
+const DEFAULT_MONTHLY = 5000;
+const DEFAULT_ANNUAL = 60000;
 
 export default function MembershipCalculator() {
-  const [income, setIncome] = useState<number>(DEFAULT_INCOME);
+  const [incomeType, setIncomeType] = useState<"monthly" | "annual">("monthly");
+  const [income, setIncome] = useState<number>(DEFAULT_MONTHLY);
   const [currency, setCurrency] = useState<string>("USD");
 
+  const max = incomeType === "monthly" ? MAX_MONTHLY : MAX_ANNUAL;
+  const step = incomeType === "monthly" ? STEP_MONTHLY : STEP_ANNUAL;
+
   const currencyData = CURRENCIES.find((c) => c.code === currency) || CURRENCIES[0];
-  const suggested = Math.round((income / 167) * 100) / 100;
+  const monthlyIncome = incomeType === "monthly" ? income : income / 12;
+  const suggested = Math.round((monthlyIncome / 167) * 100) / 100;
+  const annualSuggested = Math.round(suggested * 12 * 100) / 100;
   const isUSD = currency === "USD";
   const usdSuggested = Math.round(suggested * currencyData.usdRate);
+  const usdAnnualSuggested = Math.round(annualSuggested * currencyData.usdRate);
+
+  const handleIncomeTypeChange = (newType: "monthly" | "annual") => {
+    setIncomeType(newType);
+    setIncome(newType === "monthly" ? DEFAULT_MONTHLY : DEFAULT_ANNUAL);
+  };
 
   return (
     <Box
@@ -49,6 +64,28 @@ export default function MembershipCalculator() {
       >
         Calculate Your Suggested Contribution
       </Typography>
+
+      {/* Income Period */}
+      <Box sx={{ mb: 2 }}>
+        <FormLabel component="legend" sx={{ display: "block", mb: 1, fontWeight: 600, color: "#1f2937", fontSize: "0.875rem" }}>
+          Income Period
+        </FormLabel>
+        <FormControl component="fieldset">
+          <RadioGroup
+            row
+            value={incomeType}
+            onChange={(e) => handleIncomeTypeChange(e.target.value as "monthly" | "annual")}
+            sx={{
+              gap: 1,
+              "& .MuiFormControlLabel-label": { fontSize: "0.875rem", color: "#374151" },
+              "& .MuiRadio-root": { color: "#9ca3af", "&.Mui-checked": { color: "#168039" } },
+            }}
+          >
+            <FormControlLabel value="monthly" control={<Radio size="small" />} label="Monthly Income" />
+            <FormControlLabel value="annual" control={<Radio size="small" />} label="Annual Income" />
+          </RadioGroup>
+        </FormControl>
+      </Box>
 
       {/* Currency */}
       <Box sx={{ mb: 2.5 }}>
@@ -80,18 +117,18 @@ export default function MembershipCalculator() {
       <Box sx={{ mb: 1 }}>
         <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", mb: 1 }}>
           <FormLabel sx={{ fontWeight: 600, color: "#1f2937", fontSize: "0.875rem" }}>
-            Monthly Income
+            {incomeType === "monthly" ? "Monthly" : "Annual"} Income
           </FormLabel>
           <Typography sx={{ fontSize: "1rem", fontWeight: 600, color: "#374151" }}>
-            {currencyData.symbol}{income.toLocaleString()}{income === MAX_INCOME ? "+" : ""}
+            {currencyData.symbol}{income.toLocaleString()}{income === max ? "+" : ""}
           </Typography>
         </Box>
         <Box sx={{ px: 0.5 }}>
           <Slider
             value={income}
             min={MIN_INCOME}
-            max={MAX_INCOME}
-            step={STEP}
+            max={max}
+            step={step}
             onChange={(_, val) => setIncome(val as number)}
             sx={{
               color: "#9ca3af",
@@ -111,36 +148,49 @@ export default function MembershipCalculator() {
         </Box>
         <Box sx={{ display: "flex", justifyContent: "space-between" }}>
           <Typography sx={{ fontSize: "0.75rem", color: "#9ca3af" }}>{currencyData.symbol}0</Typography>
-          <Typography sx={{ fontSize: "0.75rem", color: "#9ca3af" }}>{currencyData.symbol}{MAX_INCOME.toLocaleString()}+</Typography>
+          <Typography sx={{ fontSize: "0.75rem", color: "#9ca3af" }}>{currencyData.symbol}{max.toLocaleString()}+</Typography>
         </Box>
       </Box>
 
       {/* Result */}
       {income > 0 && (
-        <Box
-          sx={{
-            mt: 2.5,
-            p: 2,
-            backgroundColor: "#f0fdf4",
-            borderRadius: 2,
-            border: "1px solid #bbf7d0",
-          }}
-        >
-          <Typography sx={{ fontWeight: 600, color: "#166534", mb: 0.5, fontSize: "0.875rem" }}>
-            Suggested Monthly Contribution
-          </Typography>
-          <Typography sx={{ fontSize: "1.75rem", fontWeight: "bold", color: "#168039" }}>
-            {currencyData.symbol}{suggested.toFixed(2)}
-            {!isUSD && (
-              <Typography component="span" sx={{ fontWeight: 400, color: "#6b7280", fontSize: "1rem", ml: 1 }}>
-                (~${usdSuggested})
+        <Box sx={{ mt: 2.5, display: "flex", gap: 2, flexWrap: "wrap" }}>
+          <Box sx={{ flex: 1, p: 2, backgroundColor: "#f0fdf4", borderRadius: 2, border: "1px solid #bbf7d0" }}>
+            <Typography sx={{ fontWeight: 600, color: "#166534", mb: 0.5, fontSize: "0.875rem" }}>
+              Suggested Monthly Contribution
+            </Typography>
+            <Typography sx={{ fontSize: "1.75rem", fontWeight: "bold", color: "#168039" }}>
+              {currencyData.symbol}{suggested.toFixed(2)}
+              {!isUSD && (
+                <Typography component="span" sx={{ fontWeight: 400, color: "#6b7280", fontSize: "1rem", ml: 1 }}>
+                  (~${usdSuggested})
+                </Typography>
+              )}
+            </Typography>
+          </Box>
+
+          {incomeType === "annual" && (
+            <Box sx={{ flex: 1, p: 2, backgroundColor: "#f0fdf4", borderRadius: 2, border: "1px solid #bbf7d0" }}>
+              <Typography sx={{ fontWeight: 600, color: "#166534", mb: 0.5, fontSize: "0.875rem" }}>
+                Suggested Annual Contribution
               </Typography>
-            )}
-          </Typography>
-          <Typography sx={{ fontSize: "0.8rem", color: "#4b5563", mt: 0.5, fontStyle: "italic" }}>
-            ≈ one hour of your time. Contribute what feels right to you.
-          </Typography>
+              <Typography sx={{ fontSize: "1.75rem", fontWeight: "bold", color: "#168039" }}>
+                {currencyData.symbol}{annualSuggested.toFixed(2)}
+                {!isUSD && (
+                  <Typography component="span" sx={{ fontWeight: 400, color: "#6b7280", fontSize: "1rem", ml: 1 }}>
+                    (~${usdAnnualSuggested})
+                  </Typography>
+                )}
+              </Typography>
+            </Box>
+          )}
         </Box>
+      )}
+
+      {income > 0 && (
+        <Typography sx={{ fontSize: "0.8rem", color: "#4b5563", mt: 1.5, fontStyle: "italic" }}>
+          ≈ one hour of your time. Contribute what feels right to you.
+        </Typography>
       )}
     </Box>
   );


### PR DESCRIPTION
## Summary

- Replaces the text-input `MembershipCalculator` with a minimal horizontal slider
- Users drag to indicate their monthly income; suggested contribution (income ÷ 167 ≈ one hour's pay) appears below
- Keeps multi-currency support in a compact dropdown
- Removes heavy green border — less visually intrusive than the previous widget

## Test plan

- [x] Visit the membership page and confirm the slider renders correctly
- [x] Drag the slider and verify the suggested amount updates in real time
- [x] Change currency and verify the symbol and USD equivalent update
- [x] Confirm suggested amount is 0 / hidden when slider is at the far left (income = 0)
- [x] Check responsive layout on mobile