### PR TITLE
fix: construct contact email via JS to prevent Cloudflare obfuscation

### DIFF
--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -72,11 +72,18 @@ import "../styles/base.css";
                 involved.
               </p>
               <a
-                href="mailto:contact@techforpalestine.org"
+                id="contact-email"
+                href="#"
                 class="font-medium text-green-700 transition-colors hover:text-green-900"
-              >
-                contact@techforpalestine.org
-              </a>
+              ></a>
+              <script>
+                (function () {
+                  var el = document.getElementById("contact-email");
+                  var e = "contact" + "@" + "techforpalestine.org";
+                  el.href = "mailto:" + e;
+                  el.textContent = e;
+                })();
+              </script>
             </div>
 
             <!-- Media & Press -->

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -78,7 +78,8 @@ import "../styles/base.css";
               ></a>
               <script>
                 (function () {
-                  var el = document.getElementById("contact-email");
+                  var el = document.getElementById("contact-email") as HTMLAnchorElement | null;
+                  if (!el) return;
                   var e = "contact" + "@" + "techforpalestine.org";
                   el.href = "mailto:" + e;
                   el.textContent = e;


### PR DESCRIPTION
## Summary

- Cloudflare's Email Address Obfuscation feature encodes raw email addresses in HTML, then loads `cdn-cgi/scripts/.../email-decode.min.js` to reverse the encoding for real users
- That decode script is blocked by our `strict-dynamic` CSP (which disables host-based allowlisting), causing visitors to see `[email protected]` instead of `contact@techforpalestine.org`
- Fix: build the email string at runtime via JS so no raw address appears in the server-rendered HTML — Cloudflare's scanner has nothing to encode, and the link works correctly for all users
- The inline script gets a nonce automatically from our `HTMLRewriter` in `csp.ts`

## Note

Other pages (`legal.astro`, `terms.astro`, `privacy-policy.astro`, `media.astro`, `donate.astro`, etc.) also contain raw email addresses and are affected by the same issue. The recommended fix for those is to **disable Cloudflare Email Address Obfuscation** in the dashboard (Scrape Shield → Email Address Obfuscation → Off), since the feature is incompatible with our strict-dynamic CSP and provides negligible anti-spam value against modern scrapers.

## Test plan

- [x] Visit `/contact` and confirm `contact@techforpalestine.org` renders correctly and the `mailto:` link works
- [x] Confirm no CSP violation for `email-decode.min.js` in the browser console on the contact page