### PR TITLE
fix: prefix Mattermost notifications with [Website] label

### DIFF
--- a/src/pages/api/sentry-webhook.ts
+++ b/src/pages/api/sentry-webhook.ts
@@ -50,7 +50,7 @@ function formatMessage(body: Record<string, any>): string {
     const label = actionLabel[action] ?? `Issue ${action}`;
 
     return [
-      `**${label}** in **${project}**${envTag}`,
+      `**[Website]** ${label} in **${project}**${envTag}`,
       `**${title}**`,
       url ? `[View in Sentry](${url})` : "",
     ]
@@ -65,7 +65,7 @@ function formatMessage(body: Record<string, any>): string {
     const envTag = env ? ` \`${env}\`` : "";
 
     return [
-      `**🚨 Alert triggered**${rule ? `: ${rule}` : ""}${envTag}`,
+      `**[Website]** 🚨 Alert triggered${rule ? `: ${rule}` : ""}${envTag}`,
       `**${title}**`,
       url ? `[View in Sentry](${url})` : "",
     ]


### PR DESCRIPTION
## Summary

Prefixes all Sentry → Mattermost notifications with `[Website]` so they're distinguishable from other platforms posting to the same channel.

Example output:
- `**[Website]** 🔴 New issue in javascript-astro \`preview\``
- `**[Website]** 🚨 Alert triggered: New Issue \`production\``