### PR TITLE
fix: show Brussels banner tagline on all breakpoints

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -185,8 +185,8 @@ const canonicalUrl = new URL(
         </div>
 
         <!-- Tagline -->
-        <div class="hidden shrink-0 items-center lg:flex">
-          <span class="text-sm italic text-[#F2EFE2]/80">
+        <div class="flex shrink-0 items-center justify-center lg:justify-start">
+          <span class="text-xs italic text-[#F2EFE2]/80 md:text-sm">
             More details about the event TBA soon
           </span>
         </div>


### PR DESCRIPTION
## Summary
- The "More details about the event TBA soon" tagline was hidden below `lg`, so mobile users never saw it. This change makes it visible on every breakpoint, with a slightly smaller font on mobile to fit the stacked layout.

## Test plan
- [ ] Verify the tagline appears on mobile, `md`, and `lg` widths.
- [ ] Confirm the desktop layout still reads as a clean three-column row.