### PR TITLE
fix(csp): encode @ in email addresses to prevent Cloudflare obfuscation CSP violation

### DIFF
--- a/src/pages/donate-2.astro
+++ b/src/pages/donate-2.astro
@@ -175,7 +175,7 @@ import "../styles/base.css";
               methods.
             </p>
             <p class="mt-3 text-gray-700">
-              Email <b>donations@techforpalestine.org</b> and we'll assist you.
+              Email <b>donations&#64;techforpalestine.org</b> and we'll assist you.
             </p>
           </div>
         </div>

--- a/src/pages/donate.astro
+++ b/src/pages/donate.astro
@@ -228,7 +228,7 @@ const isUK = country === "GB";
                 href="https://thegivingblock.com/donate/tech-for-palestine"
                 target="_blank"
                 class="font-semibold text-green-700 underline hover:text-green-800">here</a
-              > or email <b>donations@techforpalestine.org</b> and we'll assist you.
+              > or email <b>donations&#64;techforpalestine.org</b> and we'll assist you.
             </p>
           </div>
         </div>

--- a/src/pages/monthly-donate.astro
+++ b/src/pages/monthly-donate.astro
@@ -32,7 +32,7 @@ import "../styles/base.css";
     <p class="mt-6 text-sm sm:text-base">Tech for Palestine is a registered 501(c)(3) nonprofit.</p>
     <p class="mt-3 text-sm sm:text-base">
       For Donor-Advised Funds, family trusts, or other structured giving, email <b
-        >donations@techforpalestine.org</b
+        >donations&#64;techforpalestine.org</b
       >.
     </p>
   </div>


### PR DESCRIPTION
## Summary

- Cloudflare Scrape Shield detects plain `@` in email addresses and injects `email-decode.min.js` to obfuscate them
- That script loads from `https://techforpalestine.org/cdn-cgi/scripts/...` which is blocked by the CSP because `strict-dynamic` disables host-based allowlisting
- Result: `[email protected]` shown to users instead of the real address

## Fix

Replace `@` with `&#64;` in `donations@techforpalestine.org` across all three donate pages (`donate.astro`, `donate-2.astro`, `monthly-donate.astro`). Browsers render the entity identically, but Cloudflare's scanner no longer detects an email address to obfuscate — so the decode script is never injected and the CSP violation disappears.