### PR TITLE
feat(ci): add security scan workflow for PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -18,10 +18,17 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-      issues: write
-      id-token: write
 
     steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 2
+
       - uses: anthropics/claude-code-security-review@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude-model: claude-sonnet-4-6
+          claudecode-timeout: 10
+          exclude-directories: "node_modules,dist,.astro"
+          run-every-commit: false

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,7 +2,7 @@ name: Security Scan
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [ready_for_review]
     paths:
       - "src/pages/api/**"
       - "src/middleware/**"
@@ -11,6 +11,10 @@ on:
       - "public/_headers"
       - "wrangler.toml"
       - "*.config.*"
+
+concurrency:
+  group: security-scan-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   security-scan:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,27 @@
+name: Security Scan
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "src/pages/api/**"
+      - "src/middleware/**"
+      - "src/store/**"
+      - "src/utils/**"
+      - "public/_headers"
+      - "wrangler.toml"
+      - "*.config.*"
+
+jobs:
+  security-scan:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+
+    steps:
+      - uses: anthropics/claude-code-security-review@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary
Add an automated security scan that runs on every PR touching security-sensitive files, using Anthropic's dedicated [`claude-code-security-review`](https://github.com/anthropics/claude-code-security-review) action.

## What it does
- Scans changed files for OWASP Top 10 vulnerabilities (injection, XSS, auth bypasses, etc.) using Claude's semantic understanding
- Automatically posts findings as PR comments
- Picks up our existing CLAUDE.md security rules for project-specific context

## Cost & abuse controls
- **Trigger**: `ready_for_review` only — requires write access to trigger, preventing external spam
- **Path filter**: Only fires when security-sensitive files change (`src/pages/api/`, `src/middleware/`, `src/store/`, `src/utils/`, `public/_headers`, `wrangler.toml`, `*.config.*`)
- **Model**: Sonnet (~$0.08/scan vs ~$0.40 for Opus)
- **Timeout**: 10 minutes hard cap
- **Concurrency**: One scan per PR at a time, cancels redundant runs
- **Caching**: Built-in — won't re-scan unchanged PR content
- **Directory exclusions**: Skips `node_modules`, `dist`, `.astro`

## Setup required
Add `ANTHROPIC_API_KEY` to repo secrets (Settings → Secrets → Actions) if not already set.

## Note
PRs opened directly as non-draft won't trigger this scan (only `ready_for_review` fires it). Contributors should open as draft first, then mark ready for review.