### PR TITLE
fix(membership): correct dues calculator formula rounding error

### DIFF
--- a/src/components/MembershipCalculator.tsx
+++ b/src/components/MembershipCalculator.tsx
@@ -55,7 +55,7 @@ export default function MembershipCalculator() {
   const numericIncome = parseFloat(income);
   const hasValidIncome = !isNaN(numericIncome) && numericIncome > 0;
   const monthlyIncome = hasValidIncome ? (incomeType === "monthly" ? numericIncome : numericIncome / 12) : 0;
-  const suggestedMonthly = Math.round((monthlyIncome / 167) * 100) / 100;
+  const suggestedMonthly = Math.round((monthlyIncome * 0.006) * 100) / 100;
   const suggestedAnnual = Math.round(suggestedMonthly * 12 * 100) / 100;
 
   return (


### PR DESCRIPTION
## Summary
- Fixed membership calculator using divisor `167` which produced slightly inaccurate dues suggestions (e.g. $49.90 instead of $50.00 for $100k annual income)
- Replaced with `0.006` multiplier (0.6%) for exact results

## Test plan
- [x] Enter $100,000 annual income in USD — should show exactly $50.00/month
- [x] Enter $8,333.33 monthly income in USD — should show ~$50.00/month
- [x] Verify other currencies still convert correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)