### PR TITLE
fix(webhook): report to Sentry when Plausible silently drops events

### DIFF
--- a/src/pages/api/qgiv-webhook.ts
+++ b/src/pages/api/qgiv-webhook.ts
@@ -128,11 +128,14 @@ export const POST: APIRoute = async ({ request, locals }) => {
         }),
       })
         .then(async (res) => {
-          if (res.ok) {
-            console.log(`✅ Plausible event sent: ${eventName}`);
-          } else {
+          const dropped = res.headers.get("x-plausible-dropped");
+          if (!res.ok) {
             const body = await res.text();
             reportError(new Error(`Plausible API error: ${res.status}`), { context: "Plausible API", eventName, body });
+          } else if (dropped === "1") {
+            reportError(new Error("Plausible dropped the event"), { context: "Plausible API", eventName, donorIp });
+          } else {
+            console.log(`✅ Plausible event sent: ${eventName}`);
           }
         })
         .catch((err) => reportError(err, { context: "Plausible API", eventName }));


### PR DESCRIPTION
## Problem

Plausible always returns `202 Accepted` — even when it drops an event due to bot filtering. The only way to detect a drop is via the `x-plausible-dropped: 1` response header.

Without this check, a dropped event looks identical to a successful one in our logs.

## Changes

Check `x-plausible-dropped` on every Plausible response and report to Sentry if set, so we can tell whether events are being filtered vs actually recorded.

## Next steps after merging

Trigger a test donation and check Sentry — if a "Plausible dropped the event" error appears, the issue is bot filtering (Zapier's datacenter IP). If nothing appears, events are reaching Plausible successfully and the problem is likely missing Goals configuration in the Plausible dashboard (Settings → Goals → add `Monthly-donate` and `One-time-donate` as Custom event goals).