### PR TITLE
fix(webhook): use ctx.waitUntil to ensure Plausible fetch completes

### DIFF
--- a/src/pages/api/qgiv-webhook.ts
+++ b/src/pages/api/qgiv-webhook.ts
@@ -128,11 +128,14 @@ export const POST: APIRoute = async ({ request, locals }) => {
         }),
       })
         .then(async (res) => {
-          if (res.ok) {
-            console.log(`✅ Plausible event sent: ${eventName}`);
-          } else {
+          const dropped = res.headers.get("x-plausible-dropped");
+          if (!res.ok) {
             const body = await res.text();
             reportError(new Error(`Plausible API error: ${res.status}`), { context: "Plausible API", eventName, body });
+          } else if (dropped === "1") {
+            reportError(new Error("Plausible dropped the event"), { context: "Plausible API", eventName, donorIp });
+          } else {
+            console.log(`✅ Plausible event sent: ${eventName}`);
           }
         })
         .catch((err) => reportError(err, { context: "Plausible API", eventName }));

--- a/src/pages/api/qgiv-webhook.ts
+++ b/src/pages/api/qgiv-webhook.ts
@@ -10,7 +10,9 @@ const EO_MEMBERS_LIST_URL =
   "https://emailoctopus.com/api/1.6/lists/8adc2ed4-f798-11ef-b60f-115427c25a1c/contacts";
 
 export const POST: APIRoute = async ({ request, locals }) => {
-  const runtime = (locals as { runtime?: { env?: Record<string, string> } }).runtime?.env;
+  const cf = (locals as { runtime?: { env?: Record<string, string>; ctx?: { waitUntil: (p: Promise<unknown>) => void } } }).runtime;
+  const runtime = cf?.env;
+  const ctx = cf?.ctx;
   const webhookSecret = runtime?.QGIV_WEBHOOK_SECRET ?? import.meta.env.QGIV_WEBHOOK_SECRET;
 
   const token = request.headers.get("X-Webhook-Secret");
@@ -108,7 +110,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
 
       const donorIp = request.headers.get("cf-connecting-ip") ?? request.headers.get("x-forwarded-for") ?? "";
 
-      fetch("https://plausible.io/api/event", {
+      const plausibleRequest = fetch("https://plausible.io/api/event", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -139,6 +141,8 @@ export const POST: APIRoute = async ({ request, locals }) => {
           }
         })
         .catch((err) => reportError(err, { context: "Plausible API", eventName }));
+
+      ctx?.waitUntil(plausibleRequest);
 
       return new Response(
         JSON.stringify({ success: true, donationType, eventName, formId, message: "Donation tracked" }),


### PR DESCRIPTION
## Problem

Cloudflare Workers terminate as soon as a `Response` is returned. Any un-awaited `fetch()` calls still in flight get cancelled at that point.

The Plausible tracking call is fire-and-forget (intentionally not awaited, so Zapier gets a fast response). But this means it races against worker termination — some requests complete, some get killed. This is why Plausible shows significantly fewer events than QGiv.

## Fix

Assign the Plausible promise to a variable and pass it to `ctx.waitUntil()`. This tells the Cloudflare runtime to keep the worker alive until the Plausible request finishes, while still returning the response to Zapier immediately.

## Test plan

- [ ] Trigger a test donation and verify the event appears in Plausible
- [ ] Confirm Sentry stays silent (no drops, no errors)