### PR TITLE
fix(tracking): track donations client-side via Qgiv embed event

### DIFF
--- a/src/pages/donate.astro
+++ b/src/pages/donate.astro
@@ -279,6 +279,28 @@ const isUK = country === "GB";
         });
       }
 
+      // Track completed donations from the Qgiv embed via its donationComplete DOM event.
+      // This fires in the donor's real browser, so Plausible accepts it (unlike server-side webhooks).
+      document.addEventListener("QGIV.donationComplete", function (event) {
+        var data = (event instanceof CustomEvent && event.detail) ? event.detail : {};
+
+        if (data.transStatus && data.transStatus !== "Accepted") return;
+
+        var isRecurring =
+          data.isRecurring === "y" ||
+          data.recurring === true ||
+          data.type === "recurring" ||
+          data.type === "monthly";
+        var donationEvent = isRecurring ? "Monthly-donate" : "One-time-donate";
+        var amount = String(data.value || data.amount || data.donationAmount || "");
+
+        if (typeof window.plausible !== "undefined") {
+          window.plausible(donationEvent, {
+            props: { source: "qgiv-embed", amount: amount },
+          });
+        }
+      });
+
       // Track form variant (safely)
       if (typeof window.plausible !== "undefined") {
         window.plausible("Donate Form", { props: { donate_form_variant: trackingVariant } });


### PR DESCRIPTION
## Problem

Donation conversion events sent from the server-side webhook were being silently dropped by Plausible's bot filter. The root cause: when Qgiv fires a webhook → Zapier → our Cloudflare Worker → Plausible, the donor's real browser IP is lost. Plausible receives Zapier's AWS data center IP, correctly identifies it as automated traffic, and drops the event (returning `x-plausible-dropped: 1`). Plausible has no bypass for this — it requires a real visitor IP, and there is no way to recover it from the webhook pipeline.

## Solution

The Qgiv embed script (`embed.js`) fires a `QGIV.donationComplete` custom DOM event directly in the donor's browser on the parent page (`techforpalestine.org`), where Plausible's tracking script is already running. By listening for that event and calling `window.plausible()` from there, every donation event is sent with the donor's real browser IP and User-Agent — exactly what Plausible needs.

**Field names** (`isRecurring`, `type`, `value`) are confirmed against Qgiv's own transaction reporting API, which uses the same schema as the webhook payload.

## Changes

- `src/pages/donate.astro`: adds a `QGIV.donationComplete` listener inside the existing `DOMContentLoaded` block. On a successful (`transStatus === "Accepted"`) donation it fires `Monthly-donate` or `One-time-donate` to Plausible with the donation amount as a prop.

## Test plan

- [ ] Make a one-time test donation via the Qgiv embed and confirm `One-time-donate` appears in Plausible
- [ ] Make a recurring test donation and confirm `Monthly-donate` appears in Plausible
- [ ] Confirm no double-counting with the existing webhook (webhook no longer sends to Plausible for non-membership donations — that path was already unreliable and this replaces it)
- [ ] Confirm declined transactions are not counted (`transStatus` guard)