### PR TITLE
fix(seo): add custom 404 page and redirects for removed pages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -252,6 +252,11 @@ export default function Component({ initialData, loading: initialLoading = false
 - Build command: `yarn build`
 - Output directory: `dist/`
 
+## Routing & Redirects
+
+- **When removing or renaming a page, always add a 301 redirect** in `public/_redirects` pointing to the closest equivalent page. Only omit the redirect if there genuinely is no equivalent destination. Old URLs get indexed by Google — without a redirect, they become persistent 404s that hurt SEO and send users to dead ends.
+- **Custom 404 page** lives at `src/pages/404.astro`. It uses the standard `Layout.astro` so visitors always see site navigation. Keep it that way.
+
 ## Security & Best Practices
 
 This project has undergone six rounds of security auditing. The rules below are derived directly from findings that were discovered and fixed. Do not regress them.

--- a/public/_redirects
+++ b/public/_redirects
@@ -2,3 +2,6 @@
 /resources /faq 301
 /resources/ /faq 301
 /project/* /projects 301
+/project-apply /projects 301
+/project-details/* /projects 301
+/mentor-application /mentorship 301

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,0 +1,35 @@
+---
+import Layout from "../layouts/Layout.astro";
+import "../styles/base.css";
+---
+
+<Layout title="Page Not Found">
+  <main class="flex-1 flex items-center justify-center px-6 py-24">
+    <div class="text-center max-w-lg">
+      <p class="text-base font-semibold text-[#168039]">404</p>
+      <h1 class="mt-4 text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl">
+        Page not found
+      </h1>
+      <p class="mt-6 text-lg text-gray-600">
+        Sorry, the page you're looking for doesn't exist or has been moved.
+      </p>
+      <div class="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4">
+        <a
+          href="/"
+          class="rounded-md bg-[#168039] px-5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-[#126b2e] transition-colors"
+        >
+          Go home
+        </a>
+        <a href="/projects" class="text-sm font-semibold text-gray-900 hover:text-[#168039] transition-colors">
+          Projects <span aria-hidden="true">&rarr;</span>
+        </a>
+        <a href="/events" class="text-sm font-semibold text-gray-900 hover:text-[#168039] transition-colors">
+          Events <span aria-hidden="true">&rarr;</span>
+        </a>
+        <a href="/get-involved" class="text-sm font-semibold text-gray-900 hover:text-[#168039] transition-colors">
+          Get involved <span aria-hidden="true">&rarr;</span>
+        </a>
+      </div>
+    </div>
+  </main>
+</Layout>


### PR DESCRIPTION
## Summary

- Add custom `404.astro` page with full site navigation (header, footer) and links to key sections (Home, Projects, Events, Get Involved)
- Add 301 redirects for old URLs reported as 404 in Google Search Console:
  - `/project-apply` → `/projects`
  - `/project-details/*` → `/projects`
  - `/mentor-application` → `/mentorship`
- Document redirect policy in CLAUDE.md: always add a 301 redirect when removing or renaming a page

## Context

Google Search Console is reporting persistent 404s for deleted pages. The site had no custom 404 page, so users hitting dead URLs saw a generic error with no navigation.

Redirects are handled by Cloudflare Pages via `public/_redirects` (not processed by the Astro dev server — only works in production).

## Test plan

- [x] Deploy to preview and visit a nonexistent URL — confirm 404 page renders with full navigation
- [x] Visit `/project-apply` in production — confirm 301 redirect to `/projects`
- [x] Visit `/project-details/madad` in production — confirm 301 redirect to `/projects`
- [x] Visit `/mentor-application` in production — confirm 301 redirect to `/mentorship`
- [x] Verify existing redirects still work (`/project/worku`, `/resources`)