### PR TITLE
fix(seo): exclude test and orphan pages from sitemap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,6 +256,7 @@ export default function Component({ initialData, loading: initialLoading = false
 
 - **When removing or renaming a page, always add a 301 redirect** in `public/_redirects` pointing to the closest equivalent page. Only omit the redirect if there genuinely is no equivalent destination. Old URLs get indexed by Google — without a redirect, they become persistent 404s that hurt SEO and send users to dead ends.
 - **Custom 404 page** lives at `src/pages/404.astro`. It uses the standard `Layout.astro` so visitors always see site navigation. Keep it that way.
+- **Exclude test/orphan pages from the sitemap.** Any page built for testing, staging, or experimentation — or any page not reachable via site navigation — must be added to the `filter` exclude list in the `sitemap()` config in `astro.config.mjs`. Google should only index pages that real users can navigate to.
 
 ## Security & Best Practices
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -50,6 +50,22 @@ export default defineConfig({
         },
       },
     }),
-    sitemap(),
+    sitemap({
+      filter: (page) => {
+        const exclude = [
+          "/coming-soon/",
+          "/index-new/",
+          "/incubator-new/",
+          "/project-details-temp/",
+          "/project/",
+          "/success/",
+          "/vercel/",
+          "/donate-2/",
+          "/event-details/",
+          "/404/",
+        ];
+        return !exclude.some((path) => page.endsWith(path));
+      },
+    }),
   ],
 });


### PR DESCRIPTION
## Summary

- Filter out 10 internal/test/orphan pages from the sitemap that have no navigation links pointing to them: `coming-soon`, `index-new`, `incubator-new`, `project-details-temp`, `project`, `success`, `vercel`, `donate-2`, `event-details`, `404`
- Sitemap goes from 38 URLs down to 29 real, navigable pages
- Add CLAUDE.md rule: any test or orphan page must be excluded from the sitemap config

## Test plan

- [x] Build the project and verify `dist/sitemap-0.xml` only contains navigable pages
- [x] Verify none of the excluded pages appear in the sitemap
- [x] Confirm `sitemap-index.xml` still references `sitemap-0.xml`