### PR TITLE
fix(tracking): add temporary debug event to identify recurring donation fields

### DIFF
--- a/src/pages/donate.astro
+++ b/src/pages/donate.astro
@@ -286,6 +286,19 @@ const isUK = country === "GB";
 
         if (data.transStatus && data.transStatus !== "Accepted") return;
 
+        // Temporary: capture raw field values so we can confirm the recurring field name.
+        // Remove once confirmed.
+        if (typeof window.plausible !== "undefined") {
+          window.plausible("Donation-debug", {
+            props: {
+              isRecurring: String(data.isRecurring ?? "undefined"),
+              type: String(data.type ?? "undefined"),
+              recurring: String(data.recurring ?? "undefined"),
+              keys: Object.keys(data).slice(0, 5).join(","),
+            },
+          });
+        }
+
         var isRecurring =
           data.isRecurring === "y" ||
           data.recurring === true ||


### PR DESCRIPTION
## Problem

Monthly donations via the Qgiv embed are being recorded as `One-time-donate` in Plausible. The `QGIV.donationComplete` event fires correctly, but the recurring detection check (`isRecurring === "y"`, `type === "recurring"`, etc.) isn't matching — meaning the actual field names/values Qgiv sends for a monthly donation differ from what we guessed.

## What this PR does

Adds a temporary `Donation-debug` Plausible event that fires on every `QGIV.donationComplete` and captures:
- `isRecurring` — raw value of `data.isRecurring`
- `type` — raw value of `data.type`
- `recurring` — raw value of `data.recurring`
- `keys` — first 5 keys in the payload

## Next step

After one monthly donation goes through, check the `Donation-debug` goal in Plausible's Goals section to see the actual field values, then fix the detection and remove this debug event in a follow-up PR.

## Test plan

- [x] Merge and deploy
- [x] Have donor make a monthly donation
- [x] Check Plausible Goals → `Donation-debug` → props breakdown to see raw field values