### PR TITLE
fix(tracking): look inside data.QGIV for donation fields

### DIFF
--- a/src/pages/donate.astro
+++ b/src/pages/donate.astro
@@ -288,16 +288,10 @@ const isUK = country === "GB";
 
         if (inner.transStatus && inner.transStatus !== "Accepted") return;
 
-        // Temporary: capture raw field values so we can confirm the recurring field name.
-        // Remove once confirmed.
+        // Temporary: log full payload to confirm field names. Remove once confirmed.
         if (typeof window.plausible !== "undefined") {
           window.plausible("Donation-debug", {
-            props: {
-              isRecurring: String(inner.isRecurring ?? "undefined"),
-              type: String(inner.type ?? "undefined"),
-              recurring: String(inner.recurring ?? "undefined"),
-              keys: Object.keys(inner).slice(0, 5).join(","),
-            },
+            props: { payload: JSON.stringify(inner).slice(0, 1000) },
           });
         }
 

--- a/src/pages/donate.astro
+++ b/src/pages/donate.astro
@@ -284,28 +284,30 @@ const isUK = country === "GB";
       document.addEventListener("QGIV.donationComplete", function (event) {
         var data = (event instanceof CustomEvent && event.detail) ? event.detail : {};
 
-        if (data.transStatus && data.transStatus !== "Accepted") return;
+        var inner = (data.QGIV && typeof data.QGIV === "object") ? data.QGIV : data;
+
+        if (inner.transStatus && inner.transStatus !== "Accepted") return;
 
         // Temporary: capture raw field values so we can confirm the recurring field name.
         // Remove once confirmed.
         if (typeof window.plausible !== "undefined") {
           window.plausible("Donation-debug", {
             props: {
-              isRecurring: String(data.isRecurring ?? "undefined"),
-              type: String(data.type ?? "undefined"),
-              recurring: String(data.recurring ?? "undefined"),
-              keys: Object.keys(data).slice(0, 5).join(","),
+              isRecurring: String(inner.isRecurring ?? "undefined"),
+              type: String(inner.type ?? "undefined"),
+              recurring: String(inner.recurring ?? "undefined"),
+              keys: Object.keys(inner).slice(0, 5).join(","),
             },
           });
         }
 
         var isRecurring =
-          data.isRecurring === "y" ||
-          data.recurring === true ||
-          data.type === "recurring" ||
-          data.type === "monthly";
+          inner.isRecurring === "y" ||
+          inner.recurring === true ||
+          inner.type === "recurring" ||
+          inner.type === "monthly";
         var donationEvent = isRecurring ? "Monthly-donate" : "One-time-donate";
-        var amount = String(data.value || data.amount || data.donationAmount || "");
+        var amount = String(inner.value || inner.amount || inner.donationAmount || "");
 
         if (typeof window.plausible !== "undefined") {
           window.plausible(donationEvent, {


### PR DESCRIPTION
## What

The previous debug event (#466) revealed that `event.detail` only has two keys: `event` and `QGIV`. All donation fields (`isRecurring`, `type`, `amount`, etc.) are nested inside `data.QGIV`, not at the top level — so the recurring detection and amount extraction were reading `undefined` for every field.

This PR unpacks `data.QGIV` into `inner` before reading any donation fields.

## Why the debug still stays

The `Donation-debug` event is kept but now correctly reads from `inner`, so the next monthly donation will show the actual field names and values inside `data.QGIV`. Once confirmed, a follow-up PR will remove the debug event and finalise the recurring detection.

## Test plan

- [ ] Merge and deploy
- [ ] Have donor make a monthly donation
- [ ] Check Plausible Goals → `Donation-debug` → props to confirm field names inside `data.QGIV`
- [ ] Verify `Monthly-donate` appears if field names match expectations