### PR TITLE
fix(tracking): remove transStatus guard blocking all donation events

### DIFF
--- a/src/pages/donate.astro
+++ b/src/pages/donate.astro
@@ -279,19 +279,23 @@ const isUK = country === "GB";
         });
       }
 
-      // Track completed donations from the Qgiv embed via its donationComplete DOM event.
-      // This fires in the donor's real browser, so Plausible accepts it (unlike server-side webhooks).
-      document.addEventListener("QGIV.donationComplete", function (event) {
+      // QGIV.ga4Purchase carries transaction data; QGIV.donationComplete only has contact info.
+      // Use ga4Purchase to debug the payload and find the recurring flag.
+      document.addEventListener("QGIV.ga4Purchase", function (event) {
         var data = (event instanceof CustomEvent && event.detail) ? event.detail : {};
-
         var inner = (data.QGIV && typeof data.QGIV === "object") ? data.QGIV : data;
 
-        // Temporary: log full payload to confirm field names. Remove once confirmed.
+        // Temporary: log ga4Purchase payload to find recurring field. Remove once confirmed.
         if (typeof window.plausible !== "undefined") {
           window.plausible("Donation-debug", {
             props: { payload: JSON.stringify(inner).slice(0, 1000) },
           });
         }
+      });
+
+      document.addEventListener("QGIV.donationComplete", function (event) {
+        var data = (event instanceof CustomEvent && event.detail) ? event.detail : {};
+        var inner = (data.QGIV && typeof data.QGIV === "object") ? data.QGIV : data;
 
         var isRecurring =
           inner.isRecurring === "y" ||

--- a/src/pages/donate.astro
+++ b/src/pages/donate.astro
@@ -286,8 +286,6 @@ const isUK = country === "GB";
 
         var inner = (data.QGIV && typeof data.QGIV === "object") ? data.QGIV : data;
 
-        if (inner.transStatus && inner.transStatus !== "Accepted") return;
-
         // Temporary: log full payload to confirm field names. Remove once confirmed.
         if (typeof window.plausible !== "undefined") {
           window.plausible("Donation-debug", {

--- a/src/pages/donate.astro
+++ b/src/pages/donate.astro
@@ -288,16 +288,10 @@ const isUK = country === "GB";
 
         if (inner.transStatus && inner.transStatus !== "Accepted") return;
 
-        // Temporary: capture raw field values so we can confirm the recurring field name.
-        // Remove once confirmed.
+        // Temporary: log full payload to confirm field names. Remove once confirmed.
         if (typeof window.plausible !== "undefined") {
           window.plausible("Donation-debug", {
-            props: {
-              isRecurring: String(inner.isRecurring ?? "undefined"),
-              type: String(inner.type ?? "undefined"),
-              recurring: String(inner.recurring ?? "undefined"),
-              keys: Object.keys(inner).slice(0, 5).join(","),
-            },
+            props: { payload: JSON.stringify(inner).slice(0, 1000) },
           });
         }
 

--- a/src/pages/donate.astro
+++ b/src/pages/donate.astro
@@ -284,28 +284,30 @@ const isUK = country === "GB";
       document.addEventListener("QGIV.donationComplete", function (event) {
         var data = (event instanceof CustomEvent && event.detail) ? event.detail : {};
 
-        if (data.transStatus && data.transStatus !== "Accepted") return;
+        var inner = (data.QGIV && typeof data.QGIV === "object") ? data.QGIV : data;
+
+        if (inner.transStatus && inner.transStatus !== "Accepted") return;
 
         // Temporary: capture raw field values so we can confirm the recurring field name.
         // Remove once confirmed.
         if (typeof window.plausible !== "undefined") {
           window.plausible("Donation-debug", {
             props: {
-              isRecurring: String(data.isRecurring ?? "undefined"),
-              type: String(data.type ?? "undefined"),
-              recurring: String(data.recurring ?? "undefined"),
-              keys: Object.keys(data).slice(0, 5).join(","),
+              isRecurring: String(inner.isRecurring ?? "undefined"),
+              type: String(inner.type ?? "undefined"),
+              recurring: String(inner.recurring ?? "undefined"),
+              keys: Object.keys(inner).slice(0, 5).join(","),
             },
           });
         }
 
         var isRecurring =
-          data.isRecurring === "y" ||
-          data.recurring === true ||
-          data.type === "recurring" ||
-          data.type === "monthly";
+          inner.isRecurring === "y" ||
+          inner.recurring === true ||
+          inner.type === "recurring" ||
+          inner.type === "monthly";
         var donationEvent = isRecurring ? "Monthly-donate" : "One-time-donate";
-        var amount = String(data.value || data.amount || data.donationAmount || "");
+        var amount = String(inner.value || inner.amount || inner.donationAmount || "");
 
         if (typeof window.plausible !== "undefined") {
           window.plausible(donationEvent, {


### PR DESCRIPTION
## Problem

After #467 landed, neither `One-time-donate` nor `Monthly-donate` events appeared in Plausible for real donations.

The cause: the `transStatus` guard was moved from `data.transStatus` (always `undefined` at the top level) to `inner.transStatus` (inside `data.QGIV`, where it has a real value). If the Qgiv frontend event uses any `transStatus` value other than `"Accepted"` — e.g. `"Approved"`, `"Complete"`, or something else — the function returned early and nothing fired, including the `Donation-debug` event.

## Fix

Remove the `transStatus` guard entirely. `QGIV.donationComplete` only fires on successful donations by definition — there is no reason to filter it by transaction status.

## Test plan

- [x] Merge and deploy
- [ ] Have donor make a one-time donation — confirm `One-time-donate` appears in Plausible
- [ ] Have donor make a monthly donation — confirm `Monthly-donate` appears in Plausible
- [ ] Check `Donation-debug` props to verify `isRecurring` and `type` field values