### PR TITLE
fix(tracking): debug ga4Purchase to find recurring field, remove transStatus guard

### DIFF
--- a/src/pages/donate.astro
+++ b/src/pages/donate.astro
@@ -279,21 +279,24 @@ const isUK = country === "GB";
         });
       }
 
-      // Track completed donations from the Qgiv embed via its donationComplete DOM event.
-      // This fires in the donor's real browser, so Plausible accepts it (unlike server-side webhooks).
-      document.addEventListener("QGIV.donationComplete", function (event) {
+      // QGIV.ga4Purchase carries transaction data; QGIV.donationComplete only has contact info.
+      // Debug ga4Purchase to find the recurring flag, then use donationComplete to fire Plausible.
+      document.addEventListener("QGIV.ga4Purchase", function (event) {
         var data = (event instanceof CustomEvent && event.detail) ? event.detail : {};
-
         var inner = (data.QGIV && typeof data.QGIV === "object") ? data.QGIV : data;
 
-        if (inner.transStatus && inner.transStatus !== "Accepted") return;
-
-        // Temporary: log full payload to confirm field names. Remove once confirmed.
+        // Temporary: log ga4Purchase payload to find recurring field. Remove once confirmed.
         if (typeof window.plausible !== "undefined") {
           window.plausible("Donation-debug", {
             props: { payload: JSON.stringify(inner).slice(0, 1000) },
           });
         }
+      });
+
+      document.addEventListener("QGIV.donationComplete", function (event) {
+        var data = (event instanceof CustomEvent && event.detail) ? event.detail : {};
+
+        var inner = (data.QGIV && typeof data.QGIV === "object") ? data.QGIV : data;
 
         var isRecurring =
           inner.isRecurring === "y" ||


### PR DESCRIPTION
## What

Two fixes in one:

1. **Removes the `transStatus` guard** — it was blocking all events because `QGIV.donationComplete` fires on successful donations by definition; the status check was never needed.

2. **Adds a `QGIV.ga4Purchase` debug listener** — `QGIV.donationComplete`'s `data.QGIV` only contains contact info (`contact`, `Fields`, `dedication`, `restrictions`), not transaction fields. `QGIV.ga4Purchase` follows GA4 ecommerce format and should carry the transaction data including whether it's recurring. The debug event logs its full payload to the `Donation-debug` Plausible goal.

## Test plan

- [ ] Merge and deploy
- [ ] Have donor make a one-time and a monthly donation
- [ ] Check Plausible → `Donation-debug` → `payload` prop to see full `ga4Purchase` data
- [ ] Use that to finalize the recurring detection in a follow-up PR