### PR TITLE
fix(tracking): log ga4Purchase payload to console for recurring field inspection

### DIFF
--- a/src/pages/donate.astro
+++ b/src/pages/donate.astro
@@ -282,11 +282,8 @@ const isUK = country === "GB";
       // QGIV.ga4Purchase carries transaction data; QGIV.donationComplete only has contact info.
       // Debug ga4Purchase to find the recurring flag, then use donationComplete to fire Plausible.
       document.addEventListener("QGIV.ga4Purchase", function (event) {
-        var data = (event instanceof CustomEvent && event.detail) ? event.detail : {};
-        var inner = (data.QGIV && typeof data.QGIV === "object") ? data.QGIV : data;
-
-        // Temporary: log full ga4Purchase payload. Remove once recurring field is confirmed.
-        console.log("[QGIV ga4Purchase]", JSON.stringify(inner, null, 2));
+        // Temporary: log full raw payload. Remove once recurring field is confirmed.
+        console.log("[QGIV ga4Purchase]", JSON.stringify(event.detail, null, 2));
       });
 
       document.addEventListener("QGIV.donationComplete", function (event) {

--- a/src/pages/donate.astro
+++ b/src/pages/donate.astro
@@ -285,12 +285,8 @@ const isUK = country === "GB";
         var data = (event instanceof CustomEvent && event.detail) ? event.detail : {};
         var inner = (data.QGIV && typeof data.QGIV === "object") ? data.QGIV : data;
 
-        // Temporary: log ga4Purchase payload to find recurring field. Remove once confirmed.
-        if (typeof window.plausible !== "undefined") {
-          window.plausible("Donation-debug", {
-            props: { payload: JSON.stringify(inner).slice(0, 1000) },
-          });
-        }
+        // Temporary: log full ga4Purchase payload. Remove once recurring field is confirmed.
+        console.log("[QGIV ga4Purchase]", JSON.stringify(inner, null, 2));
       });
 
       document.addEventListener("QGIV.donationComplete", function (event) {

--- a/src/pages/donate.astro
+++ b/src/pages/donate.astro
@@ -281,12 +281,12 @@ const isUK = country === "GB";
 
       // QGIV.ga4Purchase carries transaction data; QGIV.donationComplete only has contact info.
       // Debug ga4Purchase to find the recurring flag, then use donationComplete to fire Plausible.
-      // Temporary: log all QGIV events to find which fires and what data it carries.
-      ["QGIV.donationStart","QGIV.donationStepChange","QGIV.donationComplete",
-       "QGIV.ga4Purchase","QGIV.metaPixelPurchase","QGIV.pageView"].forEach(function(name) {
-        document.addEventListener(name, function(event) {
-          console.log("[QGIV]", name, JSON.stringify(event.detail, null, 2));
-        });
+      // Temporary: intercept raw postMessages from Qgiv iframe to inspect full payload.
+      window.addEventListener("message", function (event) {
+        if (event.origin !== "https://secure.qgiv.com") return;
+        var message;
+        try { message = JSON.parse(event.data); } catch (e) { return; }
+        console.log("[QGIV postMessage]", JSON.stringify(message, null, 2));
       });
 
       document.addEventListener("QGIV.donationComplete", function (event) {

--- a/src/pages/donate.astro
+++ b/src/pages/donate.astro
@@ -281,9 +281,12 @@ const isUK = country === "GB";
 
       // QGIV.ga4Purchase carries transaction data; QGIV.donationComplete only has contact info.
       // Debug ga4Purchase to find the recurring flag, then use donationComplete to fire Plausible.
-      document.addEventListener("QGIV.ga4Purchase", function (event) {
-        // Temporary: log full raw payload. Remove once recurring field is confirmed.
-        console.log("[QGIV ga4Purchase]", JSON.stringify(event.detail, null, 2));
+      // Temporary: log all QGIV events to find which fires and what data it carries.
+      ["QGIV.donationStart","QGIV.donationStepChange","QGIV.donationComplete",
+       "QGIV.ga4Purchase","QGIV.metaPixelPurchase","QGIV.pageView"].forEach(function(name) {
+        document.addEventListener(name, function(event) {
+          console.log("[QGIV]", name, JSON.stringify(event.detail, null, 2));
+        });
       });
 
       document.addEventListener("QGIV.donationComplete", function (event) {


### PR DESCRIPTION
## What

Replaces the Plausible `Donation-debug` event (which was truncating the payload) with a `console.log` of the full `ga4Purchase` payload.

## How to inspect

1. Merge and deploy
2. Open `techforpalestine.org/donate` in a browser with DevTools open (Console tab)
3. Complete a one-time donation — look for `[QGIV ga4Purchase]` log and expand the object
4. Complete a monthly donation — compare the two logs to find which field differs

Once the recurring field is identified, a follow-up PR will wire it into the `Monthly-donate` / `One-time-donate` detection and remove this log.