### PR TITLE
fix(tracking): log full donationComplete payload to find recurring field

### DIFF
--- a/src/pages/donate.astro
+++ b/src/pages/donate.astro
@@ -279,28 +279,9 @@ const isUK = country === "GB";
         });
       }
 
-      // Track donations via QGIV.ga4Purchase which carries full transaction data.
-      // ecommerce.items item_name/category identifies recurring vs one-time.
-      document.addEventListener("QGIV.ga4Purchase", function (event) {
-        var data = (event instanceof CustomEvent && event.detail) ? event.detail : {};
-        console.log("[QGIV ga4Purchase]", JSON.stringify(data, null, 2));
-        var ecommerce = data.ecommerce || {};
-        var items = Array.isArray(ecommerce.items) ? ecommerce.items : [];
-
-        var isRecurring = items.some(function (item) {
-          var text = [item.item_name, item.item_category, item.name, item.category]
-            .filter(Boolean).join(" ").toLowerCase();
-          return text.indexOf("recurring") !== -1 || text.indexOf("monthly") !== -1;
-        });
-
-        var donationEvent = isRecurring ? "Monthly-donate" : "One-time-donate";
-        var amount = String(ecommerce.value || "");
-
-        if (typeof window.plausible !== "undefined") {
-          window.plausible(donationEvent, {
-            props: { source: "qgiv-embed", amount: amount },
-          });
-        }
+      // Temporary: log full donationComplete payload to find recurring field.
+      document.addEventListener("QGIV.donationComplete", function (event) {
+        console.log("[QGIV donationComplete]", JSON.stringify(event.detail));
       });
 
       // Track form variant (safely)


### PR DESCRIPTION
## What

`QGIV.ga4Purchase` items only contain the form name — no recurring indicator. Switching back to `QGIV.donationComplete` and logging the full untruncated payload to find the recurring field.

## Test plan

- [ ] Merge and deploy
- [ ] Complete a one-time donation on the real site with DevTools open — share the `[QGIV donationComplete]` log
- [ ] Complete a monthly donation — share that log too
- [ ] Compare the two to find what differs