### PR TITLE
fix(tracking): track donations client-side via QGIV.donationComplete

### DIFF
--- a/src/pages/api/qgiv-webhook.ts
+++ b/src/pages/api/qgiv-webhook.ts
@@ -97,61 +97,8 @@ export const POST: APIRoute = async ({ request, locals }) => {
       });
     }
 
-    let donationType: "monthly" | "onetime" | null = null;
-
-    if (payload.isRecurring === "y" || payload.type === "recurring") {
-      donationType = "monthly";
-    } else if (payload.isRecurring === "n" || payload.type === "one time") {
-      donationType = "onetime";
-    }
-
-    if (donationType) {
-      const eventName = donationType === "monthly" ? "Monthly-donate" : "One-time-donate";
-
-      const donorIp = request.headers.get("cf-connecting-ip") ?? request.headers.get("x-forwarded-for") ?? "";
-
-      const plausibleRequest = fetch("https://plausible.io/api/event", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "User-Agent": "Mozilla/5.0 (compatible; T4P-Webhook/1.0)",
-          ...(donorIp && { "X-Forwarded-For": donorIp }),
-        },
-        body: JSON.stringify({
-          domain: "techforpalestine.org",
-          name: eventName,
-          url: "https://techforpalestine.org/donate",
-          props: {
-            source: "webhook",
-            form: String(payload.form?.name || "Unknown"),
-            amount: String(payload.value ?? payload.donationAmount ?? "0"),
-            transactionId: String(payload.id ?? payload.transactionId ?? ""),
-          },
-        }),
-      })
-        .then(async (res) => {
-          const dropped = res.headers.get("x-plausible-dropped");
-          if (!res.ok) {
-            const body = await res.text();
-            reportError(new Error(`Plausible API error: ${res.status}`), { context: "Plausible API", eventName, body });
-          } else if (dropped === "1") {
-            reportError(new Error("Plausible dropped the event"), { context: "Plausible API", eventName, donorIp });
-          } else {
-            console.log(`✅ Plausible event sent: ${eventName}`);
-          }
-        })
-        .catch((err) => reportError(err, { context: "Plausible API", eventName }));
-
-      ctx?.waitUntil(plausibleRequest);
-
-      return new Response(
-        JSON.stringify({ success: true, donationType, eventName, formId, message: "Donation tracked" }),
-        { status: 200, headers: { "Content-Type": "application/json" } }
-      );
-    }
-
     return new Response(
-      JSON.stringify({ success: true, message: "Webhook received but donation type unclear" }),
+      JSON.stringify({ success: true, message: "Webhook received" }),
       { status: 200, headers: { "Content-Type": "application/json" } }
     );
   } catch (error) {

--- a/src/pages/donate.astro
+++ b/src/pages/donate.astro
@@ -279,9 +279,23 @@ const isUK = country === "GB";
         });
       }
 
-      // Temporary: log full donationComplete payload to find recurring field.
       document.addEventListener("QGIV.donationComplete", function (event) {
-        console.log("[QGIV donationComplete]", JSON.stringify(event.detail));
+        var data = (event instanceof CustomEvent && event.detail) ? event.detail : {};
+        var transaction = (data.QGIV && data.QGIV.transaction) ? data.QGIV.transaction : {};
+
+        if (transaction.status !== "Accepted") return;
+
+        var isRecurring = transaction.recurring === true ||
+          (typeof transaction.frequency === "string" &&
+           transaction.frequency.toLowerCase() !== "one time");
+
+        var donationEvent = isRecurring ? "Monthly-donate" : "One-time-donate";
+
+        if (typeof window.plausible !== "undefined") {
+          window.plausible(donationEvent, {
+            props: { source: "qgiv-embed", amount: String(transaction.total || "") },
+          });
+        }
       });
 
       // Track form variant (safely)


### PR DESCRIPTION
## Summary

- **`donate.astro`**: Listens to `QGIV.donationComplete` and reads `data.QGIV.transaction` — confirmed from live payload inspection. Uses `transaction.recurring` (boolean) and `transaction.frequency` to distinguish monthly vs one-time. Uses `transaction.total` for amount and guards on `transaction.status === "Accepted"`.

- **`qgiv-webhook.ts`**: Removes the server-side Plausible tracking entirely. It was being silently dropped by Plausible's bot filter because Zapier's datacenter IP was being forwarded instead of the donor's real browser IP. Client-side tracking replaces it completely.

## Confirmed payload fields (from live donation)
```json
"transaction": {
  "frequency": "One Time",
  "recurring": false,
  "status": "Accepted",
  "total": 1
}
```

## Test plan
- [ ] One-time donation → `One-time-donate` appears in Plausible
- [ ] Monthly donation → `Monthly-donate` appears in Plausible
- [ ] Counts match Qgiv