### PR TITLE
fix(tracking): remove transaction.status guard blocking donation events

### DIFF
--- a/src/pages/donate.astro
+++ b/src/pages/donate.astro
@@ -283,8 +283,6 @@ const isUK = country === "GB";
         var data = (event instanceof CustomEvent && event.detail) ? event.detail : {};
         var transaction = (data.QGIV && data.QGIV.transaction) ? data.QGIV.transaction : {};
 
-        if (transaction.status !== "Accepted") return;
-
         var isRecurring = transaction.recurring === true ||
           (typeof transaction.frequency === "string" &&
            transaction.frequency.toLowerCase() !== "one time");


### PR DESCRIPTION
The status guard may be blocking events if the field is absent or has an unexpected value. QGIV.donationComplete fires on completion by definition so no status check is needed.