### PR TITLE
fix(tracking): await plausible callback to confirm event sent

### DIFF
--- a/src/pages/donate.astro
+++ b/src/pages/donate.astro
@@ -279,7 +279,7 @@ const isUK = country === "GB";
         });
       }
 
-      document.addEventListener("QGIV.donationComplete", function (event) {
+      document.addEventListener("QGIV.donationComplete", async function (event) {
         console.log("[T4P DEBUG] QGIV.donationComplete fired");
         console.log("[T4P DEBUG] event type:", typeof event, "| is CustomEvent:", event instanceof CustomEvent);
         console.log("[T4P DEBUG] event.detail:", JSON.stringify(event.detail, null, 2));
@@ -306,9 +306,11 @@ const isUK = country === "GB";
         console.log("[T4P DEBUG] typeof window.plausible:", typeof window.plausible);
         if (typeof window.plausible !== "undefined") {
           var props = { source: "qgiv-embed", amount: String(transaction.total || "") };
-          console.log("[T4P DEBUG] calling plausible('" + donationEvent + "', { props:", JSON.stringify(props), "})");
-          window.plausible(donationEvent, { props: props });
-          console.log("[T4P DEBUG] plausible call completed");
+          console.log("[T4P DEBUG] calling plausible (awaited) for:", donationEvent);
+          await new Promise(function (resolve) {
+            window.plausible(donationEvent, { props: props, callback: resolve });
+          });
+          console.log("[T4P DEBUG] plausible await resolved — event confirmed sent");
         } else {
           console.log("[T4P DEBUG] plausible NOT available — event NOT sent");
         }


### PR DESCRIPTION
## Summary
- Changes `window.plausible(...)` call to use the `callback` option wrapped in a `Promise`, then `await` it
- This ensures the HTTP request to Plausible actually completes before the handler returns, rather than fire-and-forget
- Debug logging kept in place from previous PR

## Why
The previous fire-and-forget call may have been cancelled if Qgiv tore down the embed or caused any page state change immediately after firing `QGIV.donationComplete`. Awaiting the callback guarantees the event is confirmed sent.

## Test
1. Go to https://techforpalestine.org/donate?variant=qgiv
2. Open DevTools console
3. Make a donation
4. Confirm you see `[T4P DEBUG] plausible await resolved — event confirmed sent`
5. Check Plausible dashboard for the event