### PR TITLE
Proxy Plausible through own domain to bypass ad blockers

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -63,6 +63,7 @@ export default defineConfig({
           "/donate-2/",
           "/event-details/",
           "/404/",
+          "/js/web.js/",
         ];
         return !exclude.some((path) => page.endsWith(path));
       },

--- a/src/components/MembershipPage.tsx
+++ b/src/components/MembershipPage.tsx
@@ -91,6 +91,27 @@ export default function MembershipPage() {
     }
   }, [showCalculator]);
 
+  useEffect(() => {
+    const variant = showCalculator ? "Calculator" : "No Calculator";
+
+    function handleDonationComplete(event: Event) {
+      const detail = (event as CustomEvent).detail ?? {};
+      const transaction = detail?.QGIV?.transaction ?? {};
+
+      if (typeof window.plausible !== "undefined") {
+        window.plausible("Membership", {
+          props: {
+            amount: String(transaction.total || ""),
+            membership_variant: variant,
+          },
+        });
+      }
+    }
+
+    document.addEventListener("QGIV.donationComplete", handleDonationComplete);
+    return () => document.removeEventListener("QGIV.donationComplete", handleDonationComplete);
+  }, [showCalculator]);
+
   return (
     <Box sx={{ maxWidth: 800, mx: "auto" }}>
       {/* Intro */}

--- a/src/components/MembershipPage.tsx
+++ b/src/components/MembershipPage.tsx
@@ -101,7 +101,7 @@ export default function MembershipPage() {
       if (typeof window.plausible !== "undefined") {
         window.plausible("Membership", {
           props: {
-            amount: String(transaction.total || ""),
+            amount: transaction.total != null ? String(transaction.total) : "",
             membership_variant: variant,
           },
         });
@@ -226,7 +226,7 @@ export default function MembershipPage() {
               Tech for Palestine aims for inclusivity. Please contact{" "}
               <a
                 href="mailto:membership@techforpalestine.org"
-                style={{ color: "#168039", textDecoration: "underline" }}
+                className="text-[#168039] underline"
               >
                 membership@techforpalestine.org
               </a>{" "}
@@ -253,7 +253,7 @@ export default function MembershipPage() {
               If you are in the US, your dues are tax deductible. If you are in the UK, contact us at{" "}
               <a
                 href="mailto:membership@techforpalestine.org"
-                style={{ color: "#168039", textDecoration: "underline" }}
+                className="text-[#168039] underline"
               >
                 membership@techforpalestine.org
               </a>{" "}
@@ -282,7 +282,7 @@ export default function MembershipPage() {
               If you have questions, set up an{" "}
               <a
                 href="https://calendly.com/d/ctpm-sw2-yvc/t4p-intro-call?month=2026-03"
-                style={{ color: "#168039", textDecoration: "underline", fontWeight: 600 }}
+                className="text-[#168039] underline font-semibold"
                 target="_blank"
                 rel="noopener noreferrer"
               >
@@ -291,7 +291,7 @@ export default function MembershipPage() {
               or reach out to us at{" "}
               <a
                 href="mailto:membership@techforpalestine.org"
-                style={{ color: "#168039", textDecoration: "underline", fontWeight: 600 }}
+                className="text-[#168039] underline font-semibold"
               >
                 membership@techforpalestine.org
               </a>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -127,8 +127,8 @@ const canonicalUrl = new URL(
     <slot name="head" />
 
     <script defer src="https://pal-chat.net/pal-chat-lite/latest/ChatBox.js"></script>
-    <!-- Privacy-friendly analytics by Plausible -->
-    <script async src="https://plausible.io/js/pa-gMn1NrWB3uBANu6ua9M8N.js"></script>
+    <!-- Privacy-friendly analytics -->
+    <script async src="/js/web.js"></script>
     <script>
       (window as any).plausible =
         (window as any).plausible ||
@@ -142,7 +142,7 @@ const canonicalUrl = new URL(
         function (i: any) {
           ((window as any).plausible as any).o = i || {};
         };
-      ((window as any).plausible as any).init();
+      ((window as any).plausible as any).init({ endpoint: "/api/pipe" });
     </script>
   </head>
   <body class="relative flex min-h-screen flex-col bg-white text-gray-900">

--- a/src/middleware/cache-control.ts
+++ b/src/middleware/cache-control.ts
@@ -3,9 +3,12 @@ import { defineMiddleware } from "astro:middleware";
 export const cacheControl = defineMiddleware(async (context, next) => {
   const response = await next();
 
-  const isApi = context.url.pathname.startsWith("/api/");
+  const pathname = context.url.pathname;
+  const isApi = pathname.startsWith("/api/");
   const isGet = context.request.method === "GET";
-  response.headers.set("Cache-Control", !isGet || isApi ? "no-store" : "public, max-age=600");
+  if (!response.headers.has("Cache-Control") || isApi || !isGet) {
+    response.headers.set("Cache-Control", !isGet || isApi ? "no-store" : "public, max-age=600");
+  }
 
   return response;
 });

--- a/src/middleware/csp.ts
+++ b/src/middleware/csp.ts
@@ -20,11 +20,11 @@ export const csp = defineMiddleware(async (context, next) => {
   const cspHeader = [
     "default-src 'self'",
     // 'strict-dynamic' trusts scripts loaded by nonced scripts; removes need for 'unsafe-inline'
-    `script-src 'nonce-${nonce}' 'strict-dynamic' https://secure.qgiv.com https://plausible.io https://pal-chat.net https://techforpalestine.org/cdn-cgi/ https://eomail4.com https://www.google.com https://www.gstatic.com https://cdn.jsdelivr.net https://prod-donation-elements-b-donationelementsjsfilesb-1m4f4dl6p6b21.s3.us-east-2.amazonaws.com`,
+    `script-src 'nonce-${nonce}' 'strict-dynamic' https://secure.qgiv.com https://pal-chat.net https://techforpalestine.org/cdn-cgi/ https://eomail4.com https://www.google.com https://www.gstatic.com https://cdn.jsdelivr.net https://prod-donation-elements-b-donationelementsjsfilesb-1m4f4dl6p6b21.s3.us-east-2.amazonaws.com`,
     `style-src 'nonce-${nonce}' 'self' https://fonts.googleapis.com https://secure.qgiv.com`,
     "font-src 'self' https://fonts.gstatic.com https://gallery.eo.page",
     "img-src 'self' data: https:",
-    "connect-src 'self' https://plausible.io https://pal-chat.net https://eomail4.com https://www.google.com https://1k0gztb8b2.execute-api.us-east-2.amazonaws.com https://www.charitystack.com https://www.donation.charitystack.com https://*.ingest.sentry.io https://*.ingest.de.sentry.io",
+    "connect-src 'self' https://pal-chat.net https://eomail4.com https://www.google.com https://1k0gztb8b2.execute-api.us-east-2.amazonaws.com https://www.charitystack.com https://www.donation.charitystack.com https://*.ingest.sentry.io https://*.ingest.de.sentry.io",
     "frame-src https://secure.qgiv.com https://calendly.com https://www.youtube.com https://www.youtube-nocookie.com https://www.google.com https://validaid.org https://www.charitystack.com",
     "object-src 'none'",
     "base-uri 'self'",

--- a/src/pages/api/pipe.ts
+++ b/src/pages/api/pipe.ts
@@ -1,0 +1,42 @@
+import type { APIRoute } from "astro";
+
+const ALLOWED_ORIGIN = "https://techforpalestine.org";
+
+export const POST: APIRoute = async ({ request }) => {
+  const origin = request.headers.get("origin");
+  if (origin && origin !== ALLOWED_ORIGIN) {
+    return new Response("Forbidden", { status: 403 });
+  }
+
+  const headers = new Headers();
+  const contentType = request.headers.get("content-type");
+  if (contentType) {
+    headers.set("content-type", contentType);
+  }
+  const userAgent = request.headers.get("user-agent");
+  if (userAgent) {
+    headers.set("user-agent", userAgent);
+  }
+
+  const forwardedFor = request.headers.get("cf-connecting-ip");
+  if (forwardedFor) {
+    headers.set("x-forwarded-for", forwardedFor);
+  }
+
+  const body = await request.text();
+
+  try {
+    const response = await fetch("https://plausible.io/api/event", {
+      method: "POST",
+      headers,
+      body,
+    });
+
+    return new Response(response.body, {
+      status: response.status,
+      headers: { "Content-Type": response.headers.get("content-type") || "text/plain" },
+    });
+  } catch {
+    return new Response("", { status: 202 });
+  }
+};

--- a/src/pages/donate-2.astro
+++ b/src/pages/donate-2.astro
@@ -185,13 +185,9 @@ import "../styles/base.css";
 
   <script>
     document.addEventListener("DOMContentLoaded", function () {
-      // Track which donate form variant the user sees
-      (window as any).plausible =
-        (window as any).plausible ||
-        function () {
-          ((window as any).plausible.q = (window as any).plausible.q || []).push(arguments);
-        };
-      (window as any).plausible("Donate Form", { props: { donate_form_variant: "charitystack" } });
+      if (typeof (window as any).plausible !== "undefined") {
+        (window as any).plausible("Donate Form", { props: { donate_form_variant: "charitystack" } });
+      }
 
       const script = document.createElement("script");
       script.defer = true;

--- a/src/pages/donate.astro
+++ b/src/pages/donate.astro
@@ -279,49 +279,22 @@ const isUK = country === "GB";
         });
       }
 
-      // Log ALL postMessage events from Qgiv iframe to discover available messages
-      window.addEventListener("message", function (event) {
-        if (typeof event.origin === "string" && event.origin.indexOf("qgiv.com") !== -1) {
-          console.log("[T4P QGIV postMessage] origin:", event.origin);
-          console.log("[T4P QGIV postMessage] data type:", typeof event.data);
-          console.log("[T4P QGIV postMessage] data:", typeof event.data === "string" ? event.data : JSON.stringify(event.data, null, 2));
-        }
-      });
-
       document.addEventListener("QGIV.donationComplete", async function (event) {
-        console.log("[T4P DEBUG] QGIV.donationComplete fired");
-        console.log("[T4P DEBUG] event type:", typeof event, "| is CustomEvent:", event instanceof CustomEvent);
-        console.log("[T4P DEBUG] event.detail:", JSON.stringify(event.detail, null, 2));
-
         var data = (event instanceof CustomEvent && event.detail) ? event.detail : {};
-        console.log("[T4P DEBUG] data.QGIV:", JSON.stringify(data.QGIV, null, 2));
-
         var transaction = (data.QGIV && data.QGIV.transaction) ? data.QGIV.transaction : {};
-        console.log("[T4P DEBUG] transaction:", JSON.stringify(transaction));
-        console.log("[T4P DEBUG] transaction.recurring:", transaction.recurring, "| type:", typeof transaction.recurring);
-        console.log("[T4P DEBUG] transaction.frequency:", transaction.frequency, "| type:", typeof transaction.frequency);
-        console.log("[T4P DEBUG] transaction.status:", transaction.status);
-        console.log("[T4P DEBUG] transaction.total:", transaction.total);
 
         var recurringByFlag = transaction.recurring === true;
         var recurringByFrequency = typeof transaction.frequency === "string" &&
           transaction.frequency.toLowerCase() !== "one time";
         var isRecurring = recurringByFlag || recurringByFrequency;
-        console.log("[T4P DEBUG] recurringByFlag:", recurringByFlag, "| recurringByFrequency:", recurringByFrequency, "| isRecurring:", isRecurring);
 
         var donationEvent = isRecurring ? "Monthly-donate" : "One-time-donate";
-        console.log("[T4P DEBUG] donationEvent:", donationEvent);
 
-        console.log("[T4P DEBUG] typeof window.plausible:", typeof window.plausible);
         if (typeof window.plausible !== "undefined") {
-          var props = { source: "qgiv-embed", amount: String(transaction.total || "") };
-          console.log("[T4P DEBUG] calling plausible (awaited) for:", donationEvent);
+          var props = { source: "qgiv-embed", amount: transaction.total != null ? String(transaction.total) : "" };
           await new Promise(function (resolve) {
             window.plausible(donationEvent, { props: props, callback: resolve });
           });
-          console.log("[T4P DEBUG] plausible await resolved — event confirmed sent");
-        } else {
-          console.log("[T4P DEBUG] plausible NOT available — event NOT sent");
         }
       });
 

--- a/src/pages/donate.astro
+++ b/src/pages/donate.astro
@@ -279,6 +279,15 @@ const isUK = country === "GB";
         });
       }
 
+      // Log ALL postMessage events from Qgiv iframe to discover available messages
+      window.addEventListener("message", function (event) {
+        if (typeof event.origin === "string" && event.origin.indexOf("qgiv.com") !== -1) {
+          console.log("[T4P QGIV postMessage] origin:", event.origin);
+          console.log("[T4P QGIV postMessage] data type:", typeof event.data);
+          console.log("[T4P QGIV postMessage] data:", typeof event.data === "string" ? event.data : JSON.stringify(event.data, null, 2));
+        }
+      });
+
       document.addEventListener("QGIV.donationComplete", async function (event) {
         console.log("[T4P DEBUG] QGIV.donationComplete fired");
         console.log("[T4P DEBUG] event type:", typeof event, "| is CustomEvent:", event instanceof CustomEvent);

--- a/src/pages/js/web.js.ts
+++ b/src/pages/js/web.js.ts
@@ -1,0 +1,27 @@
+import type { APIRoute } from "astro";
+
+const PLAUSIBLE_SCRIPT = "https://plausible.io/js/pa-gMn1NrWB3uBANu6ua9M8N.js";
+
+export const GET: APIRoute = async () => {
+  try {
+    const response = await fetch(PLAUSIBLE_SCRIPT);
+    if (!response.ok) {
+      return new Response("", {
+        status: 502,
+        headers: { "Content-Type": "text/plain" },
+      });
+    }
+
+    return new Response(response.body, {
+      headers: {
+        "Content-Type": "application/javascript",
+        "Cache-Control": "public, max-age=86400, s-maxage=86400",
+      },
+    });
+  } catch {
+    return new Response("", {
+      status: 502,
+      headers: { "Content-Type": "text/plain" },
+    });
+  }
+};


### PR DESCRIPTION
## Summary
- Route Plausible script and event API through first-party paths (`/js/web.js` and `/api/pipe`) so ad blockers can't block analytics
- Add Origin validation, error handling, and upstream fetch resilience on proxy routes
- Track membership donation amounts via `QGIV.donationComplete` listener
- Clean up debug logging from donate page, fix CSP-blocked inline styles, fix falsy-zero amount guard

## Test plan
- [x] Visit any page, verify `/js/web.js` returns Plausible script (check Network tab)
- [x] Complete a test donation on `/donate`, verify Plausible event fires through `/api/pipe`
- [x] Verify `/api/pipe` returns 403 when Origin is not techforpalestine.org
- [x] Verify `/js/web.js` returns 502 (not broken JS) if plausible.io is unreachable
- [x] Check membership page links are styled correctly (green, underlined)
- [x] Confirm no console.log output on `/donate` page