### PR TITLE
fix(tracking): flush Sentry before worker terminates in pipe endpoint

### DIFF
--- a/src/pages/api/pipe.ts
+++ b/src/pages/api/pipe.ts
@@ -78,7 +78,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
     }
 
     if (dropped || !response.ok) {
-      ctx?.waitUntil(Sentry.flush(2000));
+      ctx?.waitUntil(Promise.resolve(Sentry.flush(2000)));
     }
 
     return new Response(response.body, {
@@ -93,7 +93,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
       hasUserAgent: Boolean(userAgent),
     });
 
-    ctx?.waitUntil(Sentry.flush(2000));
+    ctx?.waitUntil(Promise.resolve(Sentry.flush(2000)));
 
     return new Response("", { status: 502 });
   }

--- a/src/pages/api/pipe.ts
+++ b/src/pages/api/pipe.ts
@@ -1,4 +1,5 @@
 import type { APIRoute } from "astro";
+import * as Sentry from "@sentry/astro";
 import { reportError } from "../../lib/report-error";
 
 const ALLOWED_ORIGIN = "https://techforpalestine.org";
@@ -13,7 +14,8 @@ function parseEventName(body: string): string {
   }
 }
 
-export const POST: APIRoute = async ({ request }) => {
+export const POST: APIRoute = async ({ request, locals }) => {
+  const ctx = (locals as { runtime?: { ctx?: { waitUntil: (p: Promise<unknown>) => void } } }).runtime?.ctx;
   const origin = request.headers.get("origin");
   if (origin && origin !== ALLOWED_ORIGIN) {
     return new Response("Forbidden", { status: 403 });
@@ -75,6 +77,10 @@ export const POST: APIRoute = async ({ request }) => {
       responseHeaders.set("x-plausible-dropped", "1");
     }
 
+    if (dropped || !response.ok) {
+      ctx?.waitUntil(Sentry.flush(2000));
+    }
+
     return new Response(response.body, {
       status: response.status,
       headers: responseHeaders,
@@ -86,6 +92,8 @@ export const POST: APIRoute = async ({ request }) => {
       hasIp: Boolean(forwardedFor),
       hasUserAgent: Boolean(userAgent),
     });
+
+    ctx?.waitUntil(Sentry.flush(2000));
 
     return new Response("", { status: 502 });
   }


### PR DESCRIPTION
## Summary

- Use `ctx.waitUntil(Sentry.flush())` to keep the Cloudflare Worker alive until Sentry events are delivered
- Without this, `reportError` queued events but the worker terminated before the HTTP request to Sentry completed — so dropped/rejected events were never reported

## Context

Follow-up to #483. Sentry reports weren't arriving because the worker returned the response and shut down before Sentry could flush its event queue. Same pattern used in `qgiv-webhook.ts`.

## Test plan

- [ ] Deploy and trigger a dropped event (e.g. donate on a VPN) — verify it appears in Sentry
- [ ] Confirm normal analytics events still flow through without delay