### PR TITLE
Store dropped Plausible conversions in Cloudflare KV

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -64,6 +64,7 @@ export default defineConfig({
           "/event-details/",
           "/404/",
           "/js/web.js/",
+          "/admin/dropped-conversions/",
         ];
         return !exclude.some((path) => page.endsWith(path));
       },

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -18,12 +18,35 @@ declare global {
   }
 }
 
+interface KVNamespace {
+  get(key: string): Promise<string | null>;
+  put(
+    key: string,
+    value: string,
+    options?: { expirationTtl?: number }
+  ): Promise<void>;
+  list(options?: {
+    prefix?: string;
+    limit?: number;
+    cursor?: string;
+  }): Promise<{
+    keys: Array<{ name: string }>;
+    list_complete: boolean;
+    cursor?: string;
+  }>;
+}
+
 declare global {
   namespace App {
     interface Locals {
       cspNonce: string;
       runtime?: {
-        env?: Record<string, string>;
+        env?: Record<string, string> & {
+          DROPPED_CONVERSIONS?: KVNamespace;
+        };
+        ctx?: {
+          waitUntil: (p: Promise<unknown>) => void;
+        };
       };
     }
   }

--- a/src/pages/admin/dropped-conversions.astro
+++ b/src/pages/admin/dropped-conversions.astro
@@ -1,0 +1,158 @@
+---
+import Layout from "../../layouts/Layout.astro";
+import "../../styles/base.css";
+import { constantTimeEqual } from "../../utils/crypto";
+import { getEnv } from "../../utils/getEnv";
+
+export const prerender = false;
+
+const token = Astro.url.searchParams.get("token");
+const expectedToken = getEnv("DROPPED_CONVERSIONS_TOKEN", Astro.locals);
+
+if (!expectedToken || !token || !constantTimeEqual(token, expectedToken)) {
+  return new Response("Unauthorized", { status: 401 });
+}
+
+const kv = Astro.locals.runtime?.env?.DROPPED_CONVERSIONS;
+if (!kv) {
+  return new Response("KV not configured", { status: 503 });
+}
+
+const dateFilter = Astro.url.searchParams.get("date") || "";
+const prefix = dateFilter ? `dropped:${dateFilter}` : "dropped:";
+
+interface DroppedEvent {
+  eventName: string;
+  timestamp: string;
+  props: Record<string, string>;
+  hasIp: boolean;
+  hasUserAgent: boolean;
+}
+
+const allKeys: string[] = [];
+let cursor: string | undefined;
+do {
+  const result = await kv.list({ prefix, limit: 1000, cursor });
+  for (const key of result.keys) {
+    allKeys.push(key.name);
+  }
+  cursor = result.list_complete ? undefined : result.cursor;
+} while (cursor);
+
+const entries = await Promise.all(
+  allKeys.map(async (key) => {
+    const raw = await kv.get(key);
+    if (!raw) return null;
+    try {
+      return JSON.parse(raw) as DroppedEvent;
+    } catch {
+      return null;
+    }
+  })
+);
+
+const events = entries.filter((e): e is DroppedEvent => e !== null).reverse();
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    timeZoneName: "short",
+  });
+}
+
+function getProp(props: Record<string, string>, ...keys: string[]): string {
+  for (const k of keys) {
+    if (props[k]) return props[k];
+  }
+  return "—";
+}
+---
+
+<Layout title="Dropped Conversions">
+  <div class="mx-auto max-w-5xl px-4 py-12 sm:px-6 lg:px-8">
+    <h1 class="text-2xl font-bold text-gray-900">Dropped Conversion Events</h1>
+    <p class="mt-2 text-sm text-gray-600">
+      Events that Plausible silently dropped (e.g. visitors on VPNs or with bot-like browsers).
+      Auto-expires after 90 days.
+    </p>
+
+    <form method="get" class="mt-6 flex items-end gap-4">
+      <input type="hidden" name="token" value={token} />
+      <div>
+        <label for="date" class="block text-sm font-medium text-gray-700">Filter by date</label>
+        <input
+          type="date"
+          id="date"
+          name="date"
+          value={dateFilter}
+          class="mt-1 block rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-green-500 focus:outline-none focus:ring-1 focus:ring-green-500"
+        />
+      </div>
+      <button
+        type="submit"
+        class="rounded-md bg-green-700 px-4 py-2 text-sm font-medium text-white hover:bg-green-800"
+      >
+        Filter
+      </button>
+      {dateFilter && (
+        <a
+          href={`?token=${token}`}
+          class="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+        >
+          Clear
+        </a>
+      )}
+    </form>
+
+    {events.length === 0 ? (
+      <div class="mt-8 rounded-lg border border-gray-200 bg-gray-50 p-8 text-center">
+        <p class="text-gray-500">No dropped conversions found{dateFilter ? ` for ${dateFilter}` : ""}.</p>
+      </div>
+    ) : (
+      <div class="mt-6 overflow-x-auto">
+        <p class="mb-3 text-sm text-gray-500">{events.length} dropped event{events.length !== 1 ? "s" : ""}</p>
+        <table class="min-w-full divide-y divide-gray-200 rounded-lg border border-gray-200">
+          <thead class="bg-gray-50">
+            <tr>
+              <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Date</th>
+              <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Event</th>
+              <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Amount</th>
+              <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Source / Variant</th>
+              <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">IP</th>
+              <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">UA</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-gray-200 bg-white">
+            {events.map((event) => (
+              <tr>
+                <td class="whitespace-nowrap px-4 py-3 text-sm text-gray-700">{formatDate(event.timestamp)}</td>
+                <td class="whitespace-nowrap px-4 py-3 text-sm font-medium text-gray-900">{event.eventName}</td>
+                <td class="whitespace-nowrap px-4 py-3 text-sm text-gray-700">
+                  {event.props.amount ? `$${event.props.amount}` : "—"}
+                </td>
+                <td class="whitespace-nowrap px-4 py-3 text-sm text-gray-700">
+                  {getProp(event.props, "source", "donate_form_variant", "membership_variant")}
+                </td>
+                <td class="whitespace-nowrap px-4 py-3 text-sm">
+                  <span class={event.hasIp ? "text-green-700" : "text-red-600"}>
+                    {event.hasIp ? "Yes" : "No"}
+                  </span>
+                </td>
+                <td class="whitespace-nowrap px-4 py-3 text-sm">
+                  <span class={event.hasUserAgent ? "text-green-700" : "text-red-600"}>
+                    {event.hasUserAgent ? "Yes" : "No"}
+                  </span>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    )}
+  </div>
+</Layout>

--- a/src/pages/api/pipe.ts
+++ b/src/pages/api/pipe.ts
@@ -4,12 +4,7 @@ import { reportError } from "../../lib/report-error";
 
 const ALLOWED_ORIGIN = "https://techforpalestine.org";
 const PLAUSIBLE_API = "https://plausible.io/api/event";
-const CONVERSION_EVENTS = new Set([
-  "Monthly-donate",
-  "One-time-donate",
-  "Membership",
-  "Donate Form",
-]);
+const CONVERSION_EVENTS = new Set(["Monthly-donate", "One-time-donate"]);
 
 function parseEventName(body: string): string {
   try {

--- a/src/pages/api/pipe.ts
+++ b/src/pages/api/pipe.ts
@@ -4,6 +4,12 @@ import { reportError } from "../../lib/report-error";
 
 const ALLOWED_ORIGIN = "https://techforpalestine.org";
 const PLAUSIBLE_API = "https://plausible.io/api/event";
+const CONVERSION_EVENTS = new Set([
+  "Monthly-donate",
+  "One-time-donate",
+  "Membership",
+  "Donate Form",
+]);
 
 function parseEventName(body: string): string {
   try {
@@ -15,7 +21,7 @@ function parseEventName(body: string): string {
 }
 
 export const POST: APIRoute = async ({ request, locals }) => {
-  const ctx = (locals as { runtime?: { ctx?: { waitUntil: (p: Promise<unknown>) => void } } }).runtime?.ctx;
+  const ctx = locals.runtime?.ctx;
   const origin = request.headers.get("origin");
   if (origin && origin !== ALLOWED_ORIGIN) {
     return new Response("Forbidden", { status: 403 });
@@ -56,6 +62,30 @@ export const POST: APIRoute = async ({ request, locals }) => {
         hasIp: Boolean(forwardedFor),
         hasUserAgent: Boolean(userAgent),
       });
+
+      if (CONVERSION_EVENTS.has(eventName)) {
+        const kv = locals.runtime?.env?.DROPPED_CONVERSIONS;
+        if (kv && ctx) {
+          const now = new Date();
+          const date = now.toISOString().slice(0, 10);
+          const time = now.toISOString().slice(11, 19).replace(/:/g, "-");
+          const id = crypto.randomUUID().slice(0, 8);
+          const key = `dropped:${date}:${time}:${id}`;
+
+          let parsed: Record<string, unknown> = {};
+          try { parsed = JSON.parse(body); } catch {}
+
+          const value = JSON.stringify({
+            eventName,
+            timestamp: now.toISOString(),
+            props: parsed.p ?? parsed.props ?? {},
+            hasIp: Boolean(forwardedFor),
+            hasUserAgent: Boolean(userAgent),
+          });
+
+          ctx.waitUntil(kv.put(key, value, { expirationTtl: 90 * 86400 }));
+        }
+      }
     }
 
     if (!response.ok) {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -7,3 +7,8 @@ pages_build_output_dir = "dist"
 
 # Notion DB IDs are set via Cloudflare Pages dashboard environment variables.
 # For local dev, add them to .env (see .env.example).
+
+[[kv_namespaces]]
+binding = "DROPPED_CONVERSIONS"
+id = "2d428a3626f846ffaa58a589565f1829"
+preview_id = "7dc503aa602743a398447364d31ffeb0"


### PR DESCRIPTION
## Summary

- When the Plausible proxy (`/api/pipe`) detects a dropped conversion event (visitors on VPNs, bot-like UAs), it now writes the event to Cloudflare KV with a 90-day TTL
- Adds a token-protected admin page at `/admin/dropped-conversions` where non-technical team members can view dropped donation events in a filterable table
- Adds proper `KVNamespace` and `ctx` types to `env.d.ts`, replacing ad-hoc casts in `pipe.ts`

## Setup required after merge

1. Set `DROPPED_CONVERSIONS_TOKEN` in Cloudflare Pages dashboard (generate with `openssl rand -hex 32`)
2. Share the URL `https://techforpalestine.org/admin/dropped-conversions?token=<token>` with the team

## Test plan

- [ ] Verify build passes on CI
- [ ] Deploy to preview and confirm `/admin/dropped-conversions` returns 401 without a valid token
- [ ] Confirm the admin page renders an empty state with a valid token
- [ ] After a dropped event occurs, verify it appears in the table