### PR TITLE
Add Sentry error reporting to all API routes

### DIFF
--- a/sentry.client.config.js
+++ b/sentry.client.config.js
@@ -2,7 +2,7 @@ import * as Sentry from "@sentry/astro";
 
 Sentry.init({
   dsn: import.meta.env.PUBLIC_SENTRY_DSN,
-  environment: import.meta.env.PUBLIC_SENTRY_ENVIRONMENT ?? "development",
+  environment: import.meta.env.PUBLIC_SENTRY_ENVIRONMENT ?? "production",
   integrations: [
     Sentry.browserTracingIntegration(),
     Sentry.captureConsoleIntegration({ levels: ["error"] }),

--- a/src/pages/api/admin/conversion-stats.ts
+++ b/src/pages/api/admin/conversion-stats.ts
@@ -1,6 +1,8 @@
 import type { APIRoute } from "astro";
+import * as Sentry from "@sentry/astro";
 import { constantTimeEqual } from "../../../utils/crypto";
 import { getEnv } from "../../../utils/getEnv";
+import { reportError } from "../../../lib/report-error";
 
 const PLAUSIBLE_API = "https://plausible.io/api/v2/query";
 const SITE_ID = "techforpalestine.org";
@@ -135,6 +137,7 @@ export const GET: APIRoute = async ({ request, locals }) => {
   const dateFrom = url.searchParams.get("date_from") || defaultFrom;
   const dateTo = url.searchParams.get("date_to") || defaultTo;
 
+  const ctx = locals.runtime?.ctx;
   try {
     const [plausible, dropped] = await Promise.all([
       apiKey
@@ -161,9 +164,10 @@ export const GET: APIRoute = async ({ request, locals }) => {
       }
     );
   } catch (error) {
-    const message =
-      error instanceof Error ? error.message : "Failed to fetch stats";
-    return new Response(JSON.stringify({ error: message }), {
+    reportError(error, { context: "conversion-stats" });
+    ctx?.waitUntil(Promise.resolve(Sentry.flush(2000)));
+
+    return new Response(JSON.stringify({ error: "Failed to fetch stats" }), {
       status: 502,
       headers: { "Content-Type": "application/json" },
     });

--- a/src/pages/api/e4p-pledge-sign.ts
+++ b/src/pages/api/e4p-pledge-sign.ts
@@ -1,10 +1,13 @@
 import type { APIRoute } from "astro";
+import * as Sentry from "@sentry/astro";
 import { Client } from "@notionhq/client";
 import { getEnv } from "../../utils/getEnv.js";
+import { reportError } from "../../lib/report-error";
 
 export const prerender = false;
 
 export const POST: APIRoute = async ({ request, locals }) => {
+  const ctx = locals.runtime?.ctx;
   const origin = request.headers.get("Origin");
   if (origin !== "https://techforpalestine.org") {
     return new Response(JSON.stringify({ error: "Forbidden" }), {
@@ -162,7 +165,8 @@ export const POST: APIRoute = async ({ request, locals }) => {
       }
     );
   } catch (error) {
-    console.error("Error processing pledge:", error);
+    reportError(error, { context: "e4p-pledge-sign" });
+    ctx?.waitUntil(Promise.resolve(Sentry.flush(2000)));
 
     return new Response(JSON.stringify({ error: "Failed to process pledge" }), {
       status: 500,

--- a/src/pages/api/e4p-signatories.ts
+++ b/src/pages/api/e4p-signatories.ts
@@ -1,10 +1,13 @@
 import type { APIRoute } from "astro";
+import * as Sentry from "@sentry/astro";
 import { Client } from "@notionhq/client";
 import { getEnv } from "../../utils/getEnv.js";
+import { reportError } from "../../lib/report-error";
 
 export const prerender = false;
 
 export const GET: APIRoute = async ({ locals }) => {
+  const ctx = locals.runtime?.ctx;
   try {
     const notionSecret = getEnv("NOTION_SECRET", locals);
     const databaseId = getEnv("NOTION_SIGNATORIES_DB_ID", locals);
@@ -55,7 +58,8 @@ export const GET: APIRoute = async ({ locals }) => {
       },
     });
   } catch (error) {
-    console.error("Error fetching signatories:", error);
+    reportError(error, { context: "e4p-signatories" });
+    ctx?.waitUntil(Promise.resolve(Sentry.flush(2000)));
 
     return new Response(JSON.stringify({ error: "Failed to fetch signatories" }), {
       status: 500,

--- a/src/pages/api/endorsement-request.ts
+++ b/src/pages/api/endorsement-request.ts
@@ -1,10 +1,13 @@
 import type { APIRoute } from "astro";
+import * as Sentry from "@sentry/astro";
 import { Client } from "@notionhq/client";
 import { getEnv } from "../../utils/getEnv.js";
+import { reportError } from "../../lib/report-error";
 
 export const prerender = false;
 
 export const POST: APIRoute = async ({ request, locals }) => {
+  const ctx = locals.runtime?.ctx;
   const origin = request.headers.get("Origin");
   if (origin !== "https://techforpalestine.org") {
     return new Response(JSON.stringify({ error: "Forbidden" }), {
@@ -197,7 +200,8 @@ export const POST: APIRoute = async ({ request, locals }) => {
       }
     );
   } catch (error) {
-    console.error("Error processing endorsement request:", error);
+    reportError(error, { context: "endorsement-request" });
+    ctx?.waitUntil(Promise.resolve(Sentry.flush(2000)));
 
     return new Response(JSON.stringify({ error: "Failed to process endorsement request" }), {
       status: 500,

--- a/src/pages/api/events.ts
+++ b/src/pages/api/events.ts
@@ -1,9 +1,12 @@
 import type { APIRoute } from "astro";
+import * as Sentry from "@sentry/astro";
 import { fetchNotionEvents } from "../../store/notionClient";
+import { reportError } from "../../lib/report-error";
 
 export const prerender = false;
 
 export const GET: APIRoute = async ({ request, locals }) => {
+  const ctx = locals.runtime?.ctx;
   try {
     const url = new URL(request.url);
     const showAll = url.searchParams.get("showAll") === "yes";
@@ -23,7 +26,8 @@ export const GET: APIRoute = async ({ request, locals }) => {
       },
     });
   } catch (error) {
-    console.error("Error fetching events:", error);
+    reportError(error, { context: "events" });
+    ctx?.waitUntil(Promise.resolve(Sentry.flush(2000)));
 
     return new Response(JSON.stringify({ error: "Failed to fetch events" }), {
       status: 500,

--- a/src/pages/api/faq.ts
+++ b/src/pages/api/faq.ts
@@ -1,8 +1,11 @@
 import type { APIRoute } from "astro";
+import * as Sentry from "@sentry/astro";
 import { fetchNotionFAQ } from "../../store/notionClient";
+import { reportError } from "../../lib/report-error";
 
 export const prerender = false;
 export const GET: APIRoute = async ({ request, locals }) => {
+  const ctx = locals.runtime?.ctx;
   try {
     const url = new URL(request.url);
     const showAll = url.searchParams.get("showAll") === "yes";
@@ -19,7 +22,9 @@ export const GET: APIRoute = async ({ request, locals }) => {
       },
     });
   } catch (error) {
-    console.error("Error fetching FAQs:", error);
+    reportError(error, { context: "faq" });
+    ctx?.waitUntil(Promise.resolve(Sentry.flush(2000)));
+
     return new Response(JSON.stringify([]), {
       status: 500,
       headers: {

--- a/src/pages/api/ideas.ts
+++ b/src/pages/api/ideas.ts
@@ -1,9 +1,12 @@
 import type { APIRoute } from "astro";
+import * as Sentry from "@sentry/astro";
 import { fetchNotionIdeas } from "../../store/notionClient.js";
+import { reportError } from "../../lib/report-error";
 
 export const prerender = false;
 
 export const GET: APIRoute = async ({ locals }) => {
+  const ctx = locals.runtime?.ctx;
   try {
     const ideas = await fetchNotionIdeas(locals);
 
@@ -15,7 +18,9 @@ export const GET: APIRoute = async ({ locals }) => {
       },
     });
   } catch (error) {
-    console.error("Error fetching ideas:", error);
+    reportError(error, { context: "ideas" });
+    ctx?.waitUntil(Promise.resolve(Sentry.flush(2000)));
+
     return new Response(JSON.stringify({ error: "Failed to fetch ideas" }), {
       status: 500,
       headers: {

--- a/src/pages/api/membership-invite.ts
+++ b/src/pages/api/membership-invite.ts
@@ -1,5 +1,7 @@
+import * as Sentry from "@sentry/astro";
 import { constantTimeEqual } from "../../utils/crypto";
 import { getEnv } from "../../utils/getEnv";
+import { reportError } from "../../lib/report-error";
 
 export const prerender = false;
 
@@ -61,18 +63,29 @@ export async function POST({ request, locals }: { request: Request; locals: App.
   const payload: Record<string, string> = { email, type };
   if (paymentReference !== undefined) payload.paymentReference = paymentReference;
 
-  const upstream = await fetch(`${hubApiUrl}/api/auth/invite`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${hubApiKey}`,
-    },
-    body: JSON.stringify(payload),
-  });
+  const ctx = locals.runtime?.ctx;
+  try {
+    const upstream = await fetch(`${hubApiUrl}/api/auth/invite`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${hubApiKey}`,
+      },
+      body: JSON.stringify(payload),
+    });
 
-  const data = await upstream.json();
-  return new Response(JSON.stringify(data), {
-    status: upstream.status,
-    headers: { "Content-Type": "application/json" },
-  });
+    const data = await upstream.json();
+    return new Response(JSON.stringify(data), {
+      status: upstream.status,
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch (error) {
+    reportError(error, { context: "membership-invite" });
+    ctx?.waitUntil(Promise.resolve(Sentry.flush(2000)));
+
+    return new Response(JSON.stringify({ message: "Failed to process request" }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
 }

--- a/src/pages/api/project-proxy.ts
+++ b/src/pages/api/project-proxy.ts
@@ -1,5 +1,7 @@
 import type { APIRoute } from "astro";
+import * as Sentry from "@sentry/astro";
 import { getEnv } from "../../utils/getEnv.js";
+import { reportError } from "../../lib/report-error";
 
 export const prerender = false;
 
@@ -49,23 +51,33 @@ async function proxy(request: Request, locals: unknown): Promise<Response> {
   }
   headers.set("Authorization", secretKey);
 
-  const upstreamResponse = await fetch(upstream, {
-    method: request.method,
-    headers,
-    body: request.method !== "GET" && request.method !== "HEAD" ? request.body : undefined,
-    // @ts-ignore — Cloudflare Workers require this for streaming POST bodies
-    duplex: "half",
-  });
+  try {
+    const upstreamResponse = await fetch(upstream, {
+      method: request.method,
+      headers,
+      body: request.method !== "GET" && request.method !== "HEAD" ? request.body : undefined,
+      // @ts-ignore — Cloudflare Workers require this for streaming POST bodies
+      duplex: "half",
+    });
 
-  const responseHeaders = new Headers(upstreamResponse.headers);
-  // Remove hop-by-hop headers
-  responseHeaders.delete("transfer-encoding");
-  responseHeaders.delete("connection");
+    const responseHeaders = new Headers(upstreamResponse.headers);
+    responseHeaders.delete("transfer-encoding");
+    responseHeaders.delete("connection");
 
-  return new Response(upstreamResponse.body, {
-    status: upstreamResponse.status,
-    headers: responseHeaders,
-  });
+    return new Response(upstreamResponse.body, {
+      status: upstreamResponse.status,
+      headers: responseHeaders,
+    });
+  } catch (error) {
+    reportError(error, { context: "project-proxy", path: normalizedPath });
+    const ctx = (locals as any).runtime?.ctx;
+    ctx?.waitUntil(Promise.resolve(Sentry.flush(2000)));
+
+    return new Response(JSON.stringify({ error: "Failed to process request" }), {
+      status: 502,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
 }
 
 export const GET: APIRoute = ({ request, locals }) => proxy(request, locals);

--- a/src/pages/api/projects.ts
+++ b/src/pages/api/projects.ts
@@ -1,5 +1,7 @@
 import type { APIRoute } from "astro";
+import * as Sentry from "@sentry/astro";
 import { getEnv } from "../../utils/getEnv.js";
+import { reportError } from "../../lib/report-error";
 
 export const prerender = false;
 
@@ -78,6 +80,7 @@ async function fetchWithRetry(url: string, options: RequestInit & { cf?: any }, 
 }
 
 export const GET: APIRoute = async ({ locals }) => {
+  const ctx = locals.runtime?.ctx;
   const startTime = Date.now();
   try {
     const PROJECTHUB_API_KEY = getEnv("PROJECTHUB_API_KEY", locals);
@@ -154,8 +157,8 @@ export const GET: APIRoute = async ({ locals }) => {
       },
     });
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error);
-    console.error(`[API /api/projects] Fatal error:`, errorMessage, error);
+    reportError(error, { context: "projects" });
+    ctx?.waitUntil(Promise.resolve(Sentry.flush(2000)));
 
     return new Response(
       JSON.stringify({

--- a/src/pages/api/qgiv-webhook.ts
+++ b/src/pages/api/qgiv-webhook.ts
@@ -1,4 +1,5 @@
 import type { APIRoute } from "astro";
+import * as Sentry from "@sentry/astro";
 import { reportError } from "../../lib/report-error";
 import { constantTimeEqual } from "../../utils/crypto";
 import { getEnv } from "../../utils/getEnv";
@@ -11,8 +12,8 @@ const EO_MEMBERS_LIST_URL =
 
 export const POST: APIRoute = async ({ request, locals }) => {
   const cf = (locals as { runtime?: { env?: Record<string, string>; ctx?: { waitUntil: (p: Promise<unknown>) => void } } }).runtime;
-  const runtime = cf?.env;
   const ctx = cf?.ctx;
+  const runtime = cf?.env;
   const webhookSecret = runtime?.QGIV_WEBHOOK_SECRET ?? import.meta.env.QGIV_WEBHOOK_SECRET;
 
   const token = request.headers.get("X-Webhook-Secret");
@@ -23,6 +24,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
       hasSecret: Boolean(webhookSecret),
       hasToken: Boolean(token),
     });
+    ctx?.waitUntil(Promise.resolve(Sentry.flush(2000)));
     return new Response(JSON.stringify({ message: "Unauthorized" }), {
       status: 401,
       headers: { "Content-Type": "application/json" },
@@ -103,6 +105,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
     );
   } catch (error) {
     reportError(error, { context: "QGiv webhook processing" });
+    ctx?.waitUntil(Promise.resolve(Sentry.flush(2000)));
 
     return new Response(
       JSON.stringify({ error: "Failed to process webhook" }),

--- a/src/pages/api/speakers.ts
+++ b/src/pages/api/speakers.ts
@@ -1,7 +1,10 @@
 import type { APIRoute } from "astro";
+import * as Sentry from "@sentry/astro";
 import { fetchNotionAgenda } from "../../store/notionClient";
+import { reportError } from "../../lib/report-error";
 
 export const GET: APIRoute = async ({ locals }) => {
+  const ctx = locals.runtime?.ctx;
   try {
     const data = await fetchNotionAgenda(locals);
 
@@ -18,7 +21,8 @@ export const GET: APIRoute = async ({ locals }) => {
       },
     });
   } catch (error) {
-    console.error("Error fetching agenda and speakers:", error);
+    reportError(error, { context: "speakers" });
+    ctx?.waitUntil(Promise.resolve(Sentry.flush(2000)));
 
     return new Response(JSON.stringify({ error: "Failed to fetch agenda and speakers" }), {
       status: 500,


### PR DESCRIPTION
## Summary

- **Added `reportError` + `Sentry.flush`** to 10 API routes that previously only used `console.error`, making production failures visible in Sentry
- **Fixed missing `Sentry.flush`** in `qgiv-webhook.ts` — events were being captured but never flushed before the Cloudflare Worker terminated, so they could be silently lost
- **Fixed environment default inconsistency** in `sentry.client.config.js` — changed fallback from `"development"` to `"production"` to match the server config

### Routes updated
| Route | Type |
|-------|------|
| `events.ts` | Notion fetch |
| `ideas.ts` | Notion fetch |
| `speakers.ts` | Notion fetch |
| `faq.ts` | Notion fetch |
| `e4p-signatories.ts` | Notion fetch |
| `e4p-pledge-sign.ts` | Form submission |
| `endorsement-request.ts` | Form submission |
| `projects.ts` | ProjectHub proxy |
| `membership-invite.ts` | Hub API proxy |
| `project-proxy.ts` | Generic proxy |
| `admin/conversion-stats.ts` | Admin dashboard |
| `qgiv-webhook.ts` | Webhook (flush fix) |

## Test plan
- [x] `pnpm build` passes
- [ ] Deploy to preview and trigger an error in an API route — confirm it appears in Sentry dashboard
- [ ] Verify `qgiv-webhook.ts` errors now reliably appear in Sentry (previously could be lost)