### PR TITLE
feat(admin): unify conversion dashboard with membership tracking

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -64,7 +64,7 @@ export default defineConfig({
           "/event-details/",
           "/404/",
           "/js/web.js/",
-          "/admin/dropped-conversions/",
+          "/admin/conversions/",
         ];
         return !exclude.some((path) => page.endsWith(path));
       },

--- a/public/_redirects
+++ b/public/_redirects
@@ -5,3 +5,4 @@
 /project-apply /projects 301
 /project-details/* /projects 301
 /mentor-application /mentorship 301
+/admin/dropped-conversions /admin/conversions 301

--- a/src/components/ConversionDashboard.tsx
+++ b/src/components/ConversionDashboard.tsx
@@ -24,18 +24,9 @@ interface DailyCount {
   count: number;
 }
 
-interface DroppedEvent {
-  eventName: string;
-  timestamp: string;
-  props: Record<string, string>;
-  hasIp: boolean;
-  hasUserAgent: boolean;
-}
-
 interface StatsResponse {
   plausible: DailyCount[];
   dropped: DailyCount[];
-  droppedEvents: DroppedEvent[];
   dateFrom: string;
   dateTo: string;
   error?: string;
@@ -45,15 +36,17 @@ interface ConversionDashboardProps {
   token: string;
 }
 
-function formatDate(iso: string): string {
-  return new Date(iso).toLocaleDateString("en-US", {
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-  });
-}
+const GOAL_LABELS: Record<string, string> = {
+  "One-time-donate": "One-time Donation",
+  "Monthly-donate": "Monthly Donation",
+  Membership: "Membership",
+};
+
+const GOAL_COLORS: Record<string, { bg: string; border: string }> = {
+  "One-time-donate": { bg: "#16803980", border: "#168039" },
+  "Monthly-donate": { bg: "#2563eb80", border: "#2563eb" },
+  Membership: { bg: "#7c3aed80", border: "#7c3aed" },
+};
 
 function buildDateRange(days: number): [string, string] {
   const to = new Date();
@@ -62,12 +55,28 @@ function buildDateRange(days: number): [string, string] {
   return [from.toISOString().slice(0, 10), to.toISOString().slice(0, 10)];
 }
 
+function mergeCountsByGoal(
+  plausible: DailyCount[],
+  dropped: DailyCount[]
+): DailyCount[] {
+  const merged = new Map<string, number>();
+  for (const d of [...plausible, ...dropped]) {
+    const key = `${d.date}:${d.goal}`;
+    merged.set(key, (merged.get(key) || 0) + d.count);
+  }
+  return Array.from(merged, ([key, count]) => {
+    const [date, ...goalParts] = key.split(":");
+    return { date, goal: goalParts.join(":"), count };
+  });
+}
+
 export default function ConversionDashboard({
   token,
 }: ConversionDashboardProps) {
   const [defaultFrom, defaultTo] = buildDateRange(30);
   const [dateFrom, setDateFrom] = useState(defaultFrom);
   const [dateTo, setDateTo] = useState(defaultTo);
+  const [goalFilter, setGoalFilter] = useState("all");
   const [data, setData] = useState<StatsResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -106,20 +115,30 @@ export default function ConversionDashboard({
   useEffect(() => {
     if (!data || !chartRef.current) return;
 
-    const allDates = new Set<string>();
-    for (const d of data.plausible) allDates.add(d.date);
-    for (const d of data.dropped) allDates.add(d.date);
-    const dates = Array.from(allDates).sort();
+    const allCounts = mergeCountsByGoal(data.plausible, data.dropped);
 
-    const plausibleByDate = new Map<string, number>();
-    const droppedByDate = new Map<string, number>();
+    const filtered =
+      goalFilter === "all"
+        ? allCounts
+        : allCounts.filter((d) => d.goal === goalFilter);
 
-    for (const d of data.plausible) {
-      plausibleByDate.set(d.date, (plausibleByDate.get(d.date) || 0) + d.count);
-    }
-    for (const d of data.dropped) {
-      droppedByDate.set(d.date, (droppedByDate.get(d.date) || 0) + d.count);
-    }
+    const dates = Array.from(new Set(filtered.map((d) => d.date))).sort();
+    const goals = Array.from(new Set(filtered.map((d) => d.goal)));
+
+    const datasets = goals.map((goal) => {
+      const byDate = new Map<string, number>();
+      for (const d of filtered.filter((c) => c.goal === goal)) {
+        byDate.set(d.date, (byDate.get(d.date) || 0) + d.count);
+      }
+      const colors = GOAL_COLORS[goal] || { bg: "#16803980", border: "#168039" };
+      return {
+        label: GOAL_LABELS[goal] || goal,
+        data: dates.map((d) => byDate.get(d) || 0),
+        backgroundColor: colors.bg,
+        borderColor: colors.border,
+        borderWidth: 1,
+      };
+    });
 
     if (chartInstance.current) {
       chartInstance.current.destroy();
@@ -134,22 +153,7 @@ export default function ConversionDashboard({
             day: "numeric",
           })
         ),
-        datasets: [
-          {
-            label: "Tracked (Plausible)",
-            data: dates.map((d) => plausibleByDate.get(d) || 0),
-            backgroundColor: "#16803980",
-            borderColor: "#168039",
-            borderWidth: 1,
-          },
-          {
-            label: "Dropped",
-            data: dates.map((d) => droppedByDate.get(d) || 0),
-            backgroundColor: "#dc262680",
-            borderColor: "#dc2626",
-            borderWidth: 1,
-          },
-        ],
+        datasets,
       },
       options: {
         responsive: true,
@@ -177,16 +181,15 @@ export default function ConversionDashboard({
       chartInstance.current?.destroy();
       chartInstance.current = null;
     };
-  }, [data]);
+  }, [data, goalFilter]);
 
-  const totalTracked =
-    data?.plausible.reduce((sum, d) => sum + d.count, 0) || 0;
-  const totalDropped =
-    data?.dropped.reduce((sum, d) => sum + d.count, 0) || 0;
-  const dropRate =
-    totalTracked + totalDropped > 0
-      ? ((totalDropped / (totalTracked + totalDropped)) * 100).toFixed(1)
-      : "0";
+  const allCounts = data
+    ? mergeCountsByGoal(data.plausible, data.dropped)
+    : [];
+
+  const totalConversions = allCounts.reduce((sum, d) => sum + d.count, 0);
+
+  const goalKeys = ["One-time-donate", "Monthly-donate", "Membership"] as const;
 
   return (
     <div className="mx-auto max-w-6xl px-4 py-12 sm:px-6 lg:px-8">
@@ -194,11 +197,10 @@ export default function ConversionDashboard({
         Donation Conversion Dashboard
       </h1>
       <p className="mt-2 text-sm text-gray-600">
-        Tracked conversions from Plausible vs. silently dropped events (VPN
-        users, bot-like browsers).
+        Conversion events tracked across /donate and /membership pages.
       </p>
 
-      {/* Date range filter */}
+      {/* Date range + goal filter */}
       <div className="mt-6 flex flex-wrap items-end gap-4">
         <div>
           <label
@@ -231,39 +233,41 @@ export default function ConversionDashboard({
           />
         </div>
         <div className="flex gap-2">
-          <button
-            type="button"
-            onClick={() => {
-              const [f, t] = buildDateRange(7);
-              setDateFrom(f);
-              setDateTo(t);
-            }}
-            className="rounded-md border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+          {[7, 30, 90].map((days) => (
+            <button
+              key={days}
+              type="button"
+              onClick={() => {
+                const [f, t] = buildDateRange(days);
+                setDateFrom(f);
+                setDateTo(t);
+              }}
+              className="rounded-md border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+            >
+              {days}d
+            </button>
+          ))}
+        </div>
+        <div>
+          <label
+            htmlFor="goal-filter"
+            className="block text-sm font-medium text-gray-700"
           >
-            7d
-          </button>
-          <button
-            type="button"
-            onClick={() => {
-              const [f, t] = buildDateRange(30);
-              setDateFrom(f);
-              setDateTo(t);
-            }}
-            className="rounded-md border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+            Goal
+          </label>
+          <select
+            id="goal-filter"
+            value={goalFilter}
+            onChange={(e) => setGoalFilter(e.target.value)}
+            className="mt-1 block rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-green-500 focus:outline-none focus:ring-1 focus:ring-green-500"
           >
-            30d
-          </button>
-          <button
-            type="button"
-            onClick={() => {
-              const [f, t] = buildDateRange(90);
-              setDateFrom(f);
-              setDateTo(t);
-            }}
-            className="rounded-md border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
-          >
-            90d
-          </button>
+            <option value="all">All Goals</option>
+            {goalKeys.map((goal) => (
+              <option key={goal} value={goal}>
+                {GOAL_LABELS[goal]}
+              </option>
+            ))}
+          </select>
         </div>
       </div>
 
@@ -280,29 +284,37 @@ export default function ConversionDashboard({
       {data && !loading && (
         <>
           {/* Summary cards */}
-          <div className="mt-8 grid grid-cols-1 gap-4 sm:grid-cols-3">
+          <div className="mt-8 grid grid-cols-1 gap-4 sm:grid-cols-4">
             <div className="rounded-lg border border-gray-200 bg-white p-5">
               <p className="text-sm font-medium text-gray-500">
-                Tracked Conversions
+                Total Conversions
               </p>
               <p className="mt-1 text-3xl font-bold text-green-700">
-                {totalTracked}
+                {totalConversions}
               </p>
             </div>
-            <div className="rounded-lg border border-gray-200 bg-white p-5">
-              <p className="text-sm font-medium text-gray-500">
-                Dropped Conversions
-              </p>
-              <p className="mt-1 text-3xl font-bold text-red-600">
-                {totalDropped}
-              </p>
-            </div>
-            <div className="rounded-lg border border-gray-200 bg-white p-5">
-              <p className="text-sm font-medium text-gray-500">Drop Rate</p>
-              <p className="mt-1 text-3xl font-bold text-gray-900">
-                {dropRate}%
-              </p>
-            </div>
+            {goalKeys.map((goal) => {
+              const count = allCounts
+                .filter((d) => d.goal === goal)
+                .reduce((s, d) => s + d.count, 0);
+              const colors = GOAL_COLORS[goal];
+              return (
+                <div
+                  key={goal}
+                  className="rounded-lg border border-gray-200 bg-white p-5"
+                >
+                  <p className="text-sm font-medium text-gray-500">
+                    {GOAL_LABELS[goal]}
+                  </p>
+                  <p
+                    className="mt-1 text-3xl font-bold"
+                    style={{ color: colors.border }}
+                  >
+                    {count}
+                  </p>
+                </div>
+              );
+            })}
           </div>
 
           {/* Chart */}
@@ -313,131 +325,6 @@ export default function ConversionDashboard({
             <div className="relative h-80">
               <canvas ref={chartRef} />
             </div>
-          </div>
-
-          {/* Breakdown by goal */}
-          <div className="mt-8 grid grid-cols-1 gap-4 sm:grid-cols-2">
-            {["One-time-donate", "Monthly-donate"].map((goal) => {
-              const tracked =
-                data.plausible
-                  .filter((d) => d.goal === goal)
-                  .reduce((s, d) => s + d.count, 0) || 0;
-              const dropped =
-                data.dropped
-                  .filter((d) => d.goal === goal)
-                  .reduce((s, d) => s + d.count, 0) || 0;
-              const label =
-                goal === "One-time-donate" ? "One-time" : "Monthly";
-              return (
-                <div
-                  key={goal}
-                  className="rounded-lg border border-gray-200 bg-white p-5"
-                >
-                  <h3 className="text-sm font-medium text-gray-500">
-                    {label} Donations
-                  </h3>
-                  <div className="mt-2 flex items-baseline gap-4">
-                    <span className="text-2xl font-bold text-green-700">
-                      {tracked}
-                    </span>
-                    <span className="text-sm text-gray-500">tracked</span>
-                    <span className="text-2xl font-bold text-red-600">
-                      {dropped}
-                    </span>
-                    <span className="text-sm text-gray-500">dropped</span>
-                  </div>
-                </div>
-              );
-            })}
-          </div>
-
-          {/* Dropped events table */}
-          <div className="mt-8">
-            <h2 className="text-lg font-semibold text-gray-800">
-              Dropped Events Detail
-            </h2>
-            {data.droppedEvents.length === 0 ? (
-              <div className="mt-4 rounded-lg border border-gray-200 bg-gray-50 p-8 text-center">
-                <p className="text-gray-500">
-                  No dropped conversions in this date range.
-                </p>
-              </div>
-            ) : (
-              <div className="mt-4 overflow-x-auto">
-                <p className="mb-3 text-sm text-gray-500">
-                  {data.droppedEvents.length} dropped event
-                  {data.droppedEvents.length !== 1 ? "s" : ""}
-                </p>
-                <table className="min-w-full divide-y divide-gray-200 rounded-lg border border-gray-200">
-                  <thead className="bg-gray-50">
-                    <tr>
-                      <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
-                        Date
-                      </th>
-                      <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
-                        Event
-                      </th>
-                      <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
-                        Amount
-                      </th>
-                      <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
-                        Source
-                      </th>
-                      <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
-                        IP
-                      </th>
-                      <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
-                        UA
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody className="divide-y divide-gray-200 bg-white">
-                    {data.droppedEvents.map((event, i) => (
-                      <tr key={i}>
-                        <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-700">
-                          {formatDate(event.timestamp)}
-                        </td>
-                        <td className="whitespace-nowrap px-4 py-3 text-sm font-medium text-gray-900">
-                          {event.eventName}
-                        </td>
-                        <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-700">
-                          {event.props.amount
-                            ? `$${event.props.amount}`
-                            : "—"}
-                        </td>
-                        <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-700">
-                          {event.props.source ||
-                            event.props.donate_form_variant ||
-                            "—"}
-                        </td>
-                        <td className="whitespace-nowrap px-4 py-3 text-sm">
-                          <span
-                            className={
-                              event.hasIp
-                                ? "text-green-700"
-                                : "text-red-600"
-                            }
-                          >
-                            {event.hasIp ? "Yes" : "No"}
-                          </span>
-                        </td>
-                        <td className="whitespace-nowrap px-4 py-3 text-sm">
-                          <span
-                            className={
-                              event.hasUserAgent
-                                ? "text-green-700"
-                                : "text-red-600"
-                            }
-                          >
-                            {event.hasUserAgent ? "Yes" : "No"}
-                          </span>
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            )}
           </div>
         </>
       )}

--- a/src/components/ConversionDashboard.tsx
+++ b/src/components/ConversionDashboard.tsx
@@ -39,13 +39,13 @@ interface ConversionDashboardProps {
 const GOAL_LABELS: Record<string, string> = {
   "One-time-donate": "One-time Donation",
   "Monthly-donate": "Monthly Donation",
-  Membership: "Membership",
+  "Membership-complete": "Membership",
 };
 
 const GOAL_COLORS: Record<string, { bg: string; border: string }> = {
   "One-time-donate": { bg: "#16803980", border: "#168039" },
   "Monthly-donate": { bg: "#2563eb80", border: "#2563eb" },
-  Membership: { bg: "#7c3aed80", border: "#7c3aed" },
+  "Membership-complete": { bg: "#7c3aed80", border: "#7c3aed" },
 };
 
 function buildDateRange(days: number): [string, string] {
@@ -189,7 +189,7 @@ export default function ConversionDashboard({
 
   const totalConversions = allCounts.reduce((sum, d) => sum + d.count, 0);
 
-  const goalKeys = ["One-time-donate", "Monthly-donate", "Membership"] as const;
+  const goalKeys = ["One-time-donate", "Monthly-donate", "Membership-complete"] as const;
 
   return (
     <div className="mx-auto max-w-6xl px-4 py-12 sm:px-6 lg:px-8">

--- a/src/components/ConversionDashboard.tsx
+++ b/src/components/ConversionDashboard.tsx
@@ -339,12 +339,18 @@ export default function ConversionDashboard({
           {data.propBreakdowns.length > 0 && (
             <div className="mt-8 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
               {goalKeys.map((goal) => {
-                const amounts = data.propBreakdowns
-                  .filter((p) => p.goal === goal && p.prop === "amount" && p.value)
+                const allAmounts = data.propBreakdowns.filter(
+                  (p) => p.goal === goal && p.prop === "amount"
+                );
+                if (allAmounts.length === 0) return null;
+                const tracked = allAmounts
+                  .filter((p) => p.value && !isNaN(parseFloat(p.value)))
                   .sort((a, b) => parseFloat(b.value) - parseFloat(a.value));
-                if (amounts.length === 0) return null;
-                const total = amounts.reduce(
-                  (sum, p) => sum + parseFloat(p.value || "0") * p.count,
+                const untrackedCount = allAmounts
+                  .filter((p) => !p.value || isNaN(parseFloat(p.value)))
+                  .reduce((s, p) => s + p.count, 0);
+                const total = tracked.reduce(
+                  (sum, p) => sum + parseFloat(p.value) * p.count,
                   0
                 );
                 const colors = GOAL_COLORS[goal];
@@ -371,12 +377,18 @@ export default function ConversionDashboard({
                           </tr>
                         </thead>
                         <tbody>
-                          {amounts.map((a) => (
+                          {tracked.map((a) => (
                             <tr key={a.value} className="border-b border-gray-50">
                               <td className="py-1 text-gray-700">${parseFloat(a.value).toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td>
                               <td className="py-1 text-right text-gray-900 font-medium">{a.count}</td>
                             </tr>
                           ))}
+                          {untrackedCount > 0 && (
+                            <tr className="border-b border-gray-50">
+                              <td className="py-1 text-gray-400 italic">Untracked</td>
+                              <td className="py-1 text-right text-gray-400 font-medium">{untrackedCount}</td>
+                            </tr>
+                          )}
                         </tbody>
                       </table>
                     </div>

--- a/src/components/ConversionDashboard.tsx
+++ b/src/components/ConversionDashboard.tsx
@@ -24,9 +24,17 @@ interface DailyCount {
   count: number;
 }
 
+interface PropBreakdown {
+  goal: string;
+  prop: string;
+  value: string;
+  count: number;
+}
+
 interface StatsResponse {
   plausible: DailyCount[];
   dropped: DailyCount[];
+  propBreakdowns: PropBreakdown[];
   dateFrom: string;
   dateTo: string;
   error?: string;
@@ -326,6 +334,74 @@ export default function ConversionDashboard({
               <canvas ref={chartRef} />
             </div>
           </div>
+
+          {/* Property breakdowns */}
+          {data.propBreakdowns.length > 0 && (
+            <div className="mt-8 grid grid-cols-1 gap-4 sm:grid-cols-2">
+              {/* Amount totals per goal */}
+              {goalKeys.map((goal) => {
+                const amounts = data.propBreakdowns.filter(
+                  (p) => p.goal === goal && p.prop === "amount" && p.value
+                );
+                if (amounts.length === 0) return null;
+                const total = amounts.reduce(
+                  (sum, p) => sum + parseFloat(p.value || "0") * p.count,
+                  0
+                );
+                return (
+                  <div
+                    key={`amount-${goal}`}
+                    className="rounded-lg border border-gray-200 bg-white p-5"
+                  >
+                    <h3 className="text-sm font-medium text-gray-500">
+                      {GOAL_LABELS[goal]} — Total Amount
+                    </h3>
+                    <p
+                      className="mt-1 text-2xl font-bold"
+                      style={{ color: GOAL_COLORS[goal]?.border }}
+                    >
+                      ${total.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+                    </p>
+                    <p className="mt-1 text-xs text-gray-400">
+                      {amounts.reduce((s, p) => s + p.count, 0)} conversions
+                    </p>
+                  </div>
+                );
+              })}
+
+              {/* Membership variant breakdown */}
+              {(() => {
+                const variants = data.propBreakdowns.filter(
+                  (p) =>
+                    p.goal === "Membership-complete" &&
+                    p.prop === "membership_variant"
+                );
+                if (variants.length === 0) return null;
+                return (
+                  <div className="rounded-lg border border-gray-200 bg-white p-5">
+                    <h3 className="text-sm font-medium text-gray-500">
+                      Membership — Calculator Variant
+                    </h3>
+                    <div className="mt-3 space-y-2">
+                      {variants.map((v) => (
+                        <div
+                          key={v.value}
+                          className="flex items-center justify-between"
+                        >
+                          <span className="text-sm text-gray-700">
+                            {v.value || "(not set)"}
+                          </span>
+                          <span className="text-sm font-semibold text-gray-900">
+                            {v.count}
+                          </span>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                );
+              })()}
+            </div>
+          )}
         </>
       )}
     </div>

--- a/src/components/ConversionDashboard.tsx
+++ b/src/components/ConversionDashboard.tsx
@@ -335,73 +335,88 @@ export default function ConversionDashboard({
             </div>
           </div>
 
-          {/* Property breakdowns */}
+          {/* Amount breakdowns per goal */}
           {data.propBreakdowns.length > 0 && (
-            <div className="mt-8 grid grid-cols-1 gap-4 sm:grid-cols-2">
-              {/* Amount totals per goal */}
+            <div className="mt-8 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
               {goalKeys.map((goal) => {
-                const amounts = data.propBreakdowns.filter(
-                  (p) => p.goal === goal && p.prop === "amount" && p.value
-                );
+                const amounts = data.propBreakdowns
+                  .filter((p) => p.goal === goal && p.prop === "amount" && p.value)
+                  .sort((a, b) => parseFloat(b.value) - parseFloat(a.value));
                 if (amounts.length === 0) return null;
                 const total = amounts.reduce(
                   (sum, p) => sum + parseFloat(p.value || "0") * p.count,
                   0
                 );
+                const colors = GOAL_COLORS[goal];
                 return (
                   <div
                     key={`amount-${goal}`}
                     className="rounded-lg border border-gray-200 bg-white p-5"
                   >
                     <h3 className="text-sm font-medium text-gray-500">
-                      {GOAL_LABELS[goal]} — Total Amount
+                      {GOAL_LABELS[goal]}
                     </h3>
                     <p
                       className="mt-1 text-2xl font-bold"
-                      style={{ color: GOAL_COLORS[goal]?.border }}
+                      style={{ color: colors?.border }}
                     >
                       ${total.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
                     </p>
-                    <p className="mt-1 text-xs text-gray-400">
-                      {amounts.reduce((s, p) => s + p.count, 0)} conversions
-                    </p>
-                  </div>
-                );
-              })}
-
-              {/* Membership variant breakdown */}
-              {(() => {
-                const variants = data.propBreakdowns.filter(
-                  (p) =>
-                    p.goal === "Membership-complete" &&
-                    p.prop === "membership_variant"
-                );
-                if (variants.length === 0) return null;
-                return (
-                  <div className="rounded-lg border border-gray-200 bg-white p-5">
-                    <h3 className="text-sm font-medium text-gray-500">
-                      Membership — Calculator Variant
-                    </h3>
-                    <div className="mt-3 space-y-2">
-                      {variants.map((v) => (
-                        <div
-                          key={v.value}
-                          className="flex items-center justify-between"
-                        >
-                          <span className="text-sm text-gray-700">
-                            {v.value || "(not set)"}
-                          </span>
-                          <span className="text-sm font-semibold text-gray-900">
-                            {v.count}
-                          </span>
-                        </div>
-                      ))}
+                    <div className="mt-3 max-h-48 overflow-y-auto">
+                      <table className="w-full text-sm">
+                        <thead>
+                          <tr className="border-b border-gray-100">
+                            <th className="pb-1 text-left font-medium text-gray-400">Amount</th>
+                            <th className="pb-1 text-right font-medium text-gray-400">Count</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {amounts.map((a) => (
+                            <tr key={a.value} className="border-b border-gray-50">
+                              <td className="py-1 text-gray-700">${parseFloat(a.value).toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td>
+                              <td className="py-1 text-right text-gray-900 font-medium">{a.count}</td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
                     </div>
                   </div>
                 );
-              })()}
+              })}
             </div>
           )}
+
+          {/* Membership variant breakdown */}
+          {(() => {
+            const variants = data.propBreakdowns.filter(
+              (p) =>
+                p.goal === "Membership-complete" &&
+                p.prop === "membership_variant"
+            );
+            if (variants.length === 0) return null;
+            return (
+              <div className="mt-4 max-w-xs rounded-lg border border-gray-200 bg-white p-5">
+                <h3 className="text-sm font-medium text-gray-500">
+                  Membership — Calculator Variant
+                </h3>
+                <div className="mt-3 space-y-2">
+                  {variants.map((v) => (
+                    <div
+                      key={v.value}
+                      className="flex items-center justify-between"
+                    >
+                      <span className="text-sm text-gray-700">
+                        {v.value || "(not set)"}
+                      </span>
+                      <span className="text-sm font-semibold text-gray-900">
+                        {v.count}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            );
+          })()}
         </>
       )}
     </div>

--- a/src/components/MembershipPage.tsx
+++ b/src/components/MembershipPage.tsx
@@ -99,7 +99,7 @@ export default function MembershipPage() {
       const transaction = detail?.QGIV?.transaction ?? {};
 
       if (typeof window.plausible !== "undefined") {
-        window.plausible("Membership", {
+        window.plausible("Membership-complete", {
           props: {
             amount: transaction.total != null ? String(transaction.total) : "",
             membership_variant: variant,

--- a/src/pages/admin/conversions.astro
+++ b/src/pages/admin/conversions.astro
@@ -16,5 +16,5 @@ if (!expectedToken || !token || !constantTimeEqual(token, expectedToken)) {
 ---
 
 <Layout title="Conversion Dashboard">
-  <ConversionDashboard token={token} client:load />
+  <ConversionDashboard token={token} client:only="react" />
 </Layout>

--- a/src/pages/api/admin/conversion-stats.ts
+++ b/src/pages/api/admin/conversion-stats.ts
@@ -6,7 +6,7 @@ import { reportError } from "../../../lib/report-error";
 
 const PLAUSIBLE_API = "https://plausible.io/api/v2/query";
 const SITE_ID = "techforpalestine.org";
-const GOALS = ["Monthly-donate", "One-time-donate", "Membership"];
+const GOALS = ["Monthly-donate", "One-time-donate", "Membership-complete"];
 
 interface PlausibleResult {
   dimensions: string[];

--- a/src/pages/api/admin/conversion-stats.ts
+++ b/src/pages/api/admin/conversion-stats.ts
@@ -77,6 +77,60 @@ async function fetchPlausibleStats(
   return results.flat();
 }
 
+interface PropBreakdown {
+  goal: string;
+  prop: string;
+  value: string;
+  count: number;
+}
+
+async function fetchPlausiblePropBreakdown(
+  apiKey: string,
+  goal: string,
+  prop: string,
+  dateFrom: string,
+  dateTo: string
+): Promise<PropBreakdown[]> {
+  const response = await fetch(PLAUSIBLE_API, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      site_id: SITE_ID,
+      metrics: ["events"],
+      date_range: [dateFrom, dateTo],
+      filters: [["is", "event:goal", [goal]]],
+      dimensions: [`event:props:${prop}`],
+    }),
+  });
+
+  if (!response.ok) return [];
+
+  const data = (await response.json()) as { results: PlausibleResult[] };
+
+  return data.results.map((r) => ({
+    goal,
+    prop,
+    value: r.dimensions[0],
+    count: r.metrics[0],
+  }));
+}
+
+async function fetchPropertyBreakdowns(
+  apiKey: string,
+  dateFrom: string,
+  dateTo: string
+): Promise<PropBreakdown[]> {
+  const queries = [
+    ...GOALS.map((goal) => fetchPlausiblePropBreakdown(apiKey, goal, "amount", dateFrom, dateTo)),
+    fetchPlausiblePropBreakdown(apiKey, "Membership-complete", "membership_variant", dateFrom, dateTo),
+  ];
+  const results = await Promise.all(queries);
+  return results.flat();
+}
+
 async function fetchDroppedEvents(
   kv: KVNamespace,
   dateFrom: string,
@@ -149,19 +203,23 @@ export const GET: APIRoute = async ({ request, locals }) => {
 
   const ctx = locals.runtime?.ctx;
   try {
-    const [plausible, dropped] = await Promise.all([
+    const [plausible, dropped, propBreakdowns] = await Promise.all([
       apiKey
         ? fetchPlausibleStats(apiKey, dateFrom, dateTo)
         : Promise.resolve([]),
       kv
         ? fetchDroppedEvents(kv, dateFrom, dateTo)
         : Promise.resolve({ daily: [] }),
+      apiKey
+        ? fetchPropertyBreakdowns(apiKey, dateFrom, dateTo)
+        : Promise.resolve([]),
     ]);
 
     return new Response(
       JSON.stringify({
         plausible,
         dropped: dropped.daily,
+        propBreakdowns,
         dateFrom,
         dateTo,
       }),

--- a/src/pages/api/admin/conversion-stats.ts
+++ b/src/pages/api/admin/conversion-stats.ts
@@ -34,8 +34,9 @@ function defaultDateRange(): [string, string] {
   return [from.toISOString().slice(0, 10), to.toISOString().slice(0, 10)];
 }
 
-async function fetchPlausibleStats(
+async function fetchPlausibleStatsForGoal(
   apiKey: string,
+  goal: string,
   dateFrom: string,
   dateTo: string
 ): Promise<DailyCount[]> {
@@ -49,14 +50,12 @@ async function fetchPlausibleStats(
       site_id: SITE_ID,
       metrics: ["events"],
       date_range: [dateFrom, dateTo],
-      filters: [["is", "event:goal", GOALS]],
+      filters: [["is", "event:goal", [goal]]],
       dimensions: ["time:day", "event:goal"],
     }),
   });
 
-  if (!response.ok) {
-    throw new Error(`Plausible API error: ${response.status}`);
-  }
+  if (!response.ok) return [];
 
   const data = (await response.json()) as { results: PlausibleResult[] };
 
@@ -65,6 +64,17 @@ async function fetchPlausibleStats(
     goal: r.dimensions[1],
     count: r.metrics[0],
   }));
+}
+
+async function fetchPlausibleStats(
+  apiKey: string,
+  dateFrom: string,
+  dateTo: string
+): Promise<DailyCount[]> {
+  const results = await Promise.all(
+    GOALS.map((goal) => fetchPlausibleStatsForGoal(apiKey, goal, dateFrom, dateTo))
+  );
+  return results.flat();
 }
 
 async function fetchDroppedEvents(

--- a/src/pages/api/admin/conversion-stats.ts
+++ b/src/pages/api/admin/conversion-stats.ts
@@ -6,7 +6,7 @@ import { reportError } from "../../../lib/report-error";
 
 const PLAUSIBLE_API = "https://plausible.io/api/v2/query";
 const SITE_ID = "techforpalestine.org";
-const GOALS = ["Monthly-donate", "One-time-donate"];
+const GOALS = ["Monthly-donate", "One-time-donate", "Membership"];
 
 interface PlausibleResult {
   dimensions: string[];
@@ -71,7 +71,7 @@ async function fetchDroppedEvents(
   kv: KVNamespace,
   dateFrom: string,
   dateTo: string
-): Promise<{ daily: DailyCount[]; events: DroppedEvent[] }> {
+): Promise<{ daily: DailyCount[] }> {
   const allKeys: string[] = [];
   let cursor: string | undefined;
   do {
@@ -118,7 +118,7 @@ async function fetchDroppedEvents(
     daily.push({ date, goal: goalParts.join(":"), count });
   }
 
-  return { daily, events: filtered.reverse() };
+  return { daily };
 }
 
 export const GET: APIRoute = async ({ request, locals }) => {
@@ -145,14 +145,13 @@ export const GET: APIRoute = async ({ request, locals }) => {
         : Promise.resolve([]),
       kv
         ? fetchDroppedEvents(kv, dateFrom, dateTo)
-        : Promise.resolve({ daily: [], events: [] }),
+        : Promise.resolve({ daily: [] }),
     ]);
 
     return new Response(
       JSON.stringify({
         plausible,
         dropped: dropped.daily,
-        droppedEvents: dropped.events,
         dateFrom,
         dateTo,
       }),

--- a/src/pages/api/admin/conversion-stats.ts
+++ b/src/pages/api/admin/conversion-stats.ts
@@ -135,7 +135,7 @@ async function fetchDroppedEvents(
   kv: KVNamespace,
   dateFrom: string,
   dateTo: string
-): Promise<{ daily: DailyCount[] }> {
+): Promise<{ daily: DailyCount[]; propBreakdowns: PropBreakdown[] }> {
   const allKeys: string[] = [];
   let cursor: string | undefined;
   do {
@@ -182,7 +182,21 @@ async function fetchDroppedEvents(
     daily.push({ date, goal: goalParts.join(":"), count });
   }
 
-  return { daily };
+  const propCounts = new Map<string, number>();
+  for (const e of filtered) {
+    for (const [prop, value] of Object.entries(e.props)) {
+      const key = `${e.eventName}:${prop}:${value}`;
+      propCounts.set(key, (propCounts.get(key) || 0) + 1);
+    }
+  }
+
+  const propBreakdowns: PropBreakdown[] = [];
+  for (const [key, count] of propCounts) {
+    const [goal, prop, ...valueParts] = key.split(":");
+    propBreakdowns.push({ goal, prop, value: valueParts.join(":"), count });
+  }
+
+  return { daily, propBreakdowns };
 }
 
 export const GET: APIRoute = async ({ request, locals }) => {
@@ -209,7 +223,7 @@ export const GET: APIRoute = async ({ request, locals }) => {
         : Promise.resolve([]),
       kv
         ? fetchDroppedEvents(kv, dateFrom, dateTo)
-        : Promise.resolve({ daily: [] }),
+        : Promise.resolve({ daily: [], propBreakdowns: [] }),
       apiKey
         ? fetchPropertyBreakdowns(apiKey, dateFrom, dateTo)
         : Promise.resolve([]),
@@ -219,7 +233,7 @@ export const GET: APIRoute = async ({ request, locals }) => {
       JSON.stringify({
         plausible,
         dropped: dropped.daily,
-        propBreakdowns,
+        propBreakdowns: [...propBreakdowns, ...dropped.propBreakdowns],
         dateFrom,
         dateTo,
       }),

--- a/src/pages/api/pipe.ts
+++ b/src/pages/api/pipe.ts
@@ -4,7 +4,7 @@ import { reportError } from "../../lib/report-error";
 
 const ALLOWED_ORIGIN = "https://techforpalestine.org";
 const PLAUSIBLE_API = "https://plausible.io/api/event";
-const CONVERSION_EVENTS = new Set(["Monthly-donate", "One-time-donate"]);
+const CONVERSION_EVENTS = new Set(["Monthly-donate", "One-time-donate", "Membership"]);
 
 function parseEventName(body: string): string {
   try {

--- a/src/pages/api/pipe.ts
+++ b/src/pages/api/pipe.ts
@@ -3,8 +3,13 @@ import * as Sentry from "@sentry/astro";
 import { reportError } from "../../lib/report-error";
 
 const ALLOWED_ORIGIN = "https://techforpalestine.org";
+const PREVIEW_ORIGIN_SUFFIX = ".pages.dev";
 const PLAUSIBLE_API = "https://plausible.io/api/event";
 const CONVERSION_EVENTS = new Set(["Monthly-donate", "One-time-donate", "Membership"]);
+
+function isAllowedOrigin(origin: string): boolean {
+  return origin === ALLOWED_ORIGIN || origin.endsWith(PREVIEW_ORIGIN_SUFFIX);
+}
 
 function parseEventName(body: string): string {
   try {
@@ -18,7 +23,7 @@ function parseEventName(body: string): string {
 export const POST: APIRoute = async ({ request, locals }) => {
   const ctx = locals.runtime?.ctx;
   const origin = request.headers.get("origin");
-  if (origin && origin !== ALLOWED_ORIGIN) {
+  if (origin && !isAllowedOrigin(origin)) {
     return new Response("Forbidden", { status: 403 });
   }
 

--- a/src/pages/api/pipe.ts
+++ b/src/pages/api/pipe.ts
@@ -5,7 +5,7 @@ import { reportError } from "../../lib/report-error";
 const ALLOWED_ORIGIN = "https://techforpalestine.org";
 const PREVIEW_ORIGIN_SUFFIX = ".pages.dev";
 const PLAUSIBLE_API = "https://plausible.io/api/event";
-const CONVERSION_EVENTS = new Set(["Monthly-donate", "One-time-donate", "Membership"]);
+const CONVERSION_EVENTS = new Set(["Monthly-donate", "One-time-donate", "Membership-complete"]);
 
 function isAllowedOrigin(origin: string): boolean {
   return origin === ALLOWED_ORIGIN || origin.endsWith(PREVIEW_ORIGIN_SUFFIX);


### PR DESCRIPTION
## Summary
- Add **Membership** goal tracking alongside One-time and Monthly donations in the admin conversion dashboard
- Merge tracked and dropped conversions into a single unified count per goal (no more red/green distinction)
- Add **goal filter dropdown** to view all goals or filter by One-time Donation, Monthly Donation, or Membership individually
- Each goal type gets a distinct color in the chart (green for one-time, blue for monthly, purple for membership)
- Rename route from `/admin/dropped-conversions` to `/admin/conversions` with a 301 redirect from the old URL
- Also track Membership events in the Plausible pipe for KV storage of dropped events

## Test plan
- [ ] Visit `/admin/conversions?token=<token>` and verify the dashboard loads with all three goal types
- [ ] Verify the goal filter dropdown filters the chart and summary cards correctly
- [ ] Verify `/admin/dropped-conversions` redirects to `/admin/conversions` on Cloudflare Pages
- [ ] Confirm the chart shows stacked bars by goal type with correct colors
- [ ] Check that Membership conversion events from `/membership` page appear in the dashboard