### PR TITLE
feat(get-involved): add Code of Conduct link under hero subheading

### DIFF
--- a/src/pages/get-involved.astro
+++ b/src/pages/get-involved.astro
@@ -37,6 +37,9 @@ import "../styles/base.css";
           Join our mission-driven community to volunteer, collaborate, and innovate for Palestinian
           liberation. There are many ways to contribute your skills and passion.
         </p>
+        <p class="mx-auto mt-4 max-w-2xl text-base leading-8 text-gray-700">
+          Please read our <a href="https://github.com/techForPalestine/code-of-conduct" class="text-green-700 underline hover:text-green-900">Code of Conduct</a> here.
+        </p>
       </div>
     </section>
 


### PR DESCRIPTION
## Summary
- Adds a "Please read our Code of Conduct here." line under the hero subheading on the Get Involved page
- Links to https://github.com/techForPalestine/code-of-conduct in green to match the page's color scheme

## Test plan
- [x] Visit `/get-involved` and confirm the Code of Conduct line appears below the hero subheading
- [x] Confirm the link opens the correct GitHub page