### PR TITLE
chore(donate): remove temporary QGIV donationComplete debug logging

### DIFF
--- a/src/pages/donate.astro
+++ b/src/pages/donate.astro
@@ -281,18 +281,6 @@ const isUK = country === "GB";
 
       document.addEventListener("QGIV.donationComplete", async function (event) {
         var data = (event instanceof CustomEvent && event.detail) ? event.detail : {};
-        // TEMP DEBUG: remove after inspecting the payload shape for the opt-in checkbox field
-        try {
-          var debugBox = document.createElement("pre");
-          debugBox.id = "qgiv-debug-payload";
-          debugBox.style.cssText =
-            "position:fixed;top:0;left:0;right:0;z-index:99999;max-height:60vh;overflow:auto;" +
-            "background:#111;color:#0f0;font-size:12px;padding:12px;margin:0;white-space:pre-wrap;word-break:break-all;";
-          debugBox.textContent = "QGIV.donationComplete event.detail:\n" + JSON.stringify(data, null, 2);
-          document.body.appendChild(debugBox);
-        } catch (e) {
-          console.log("QGIV debug render failed", e);
-        }
         var transaction = (data.QGIV && data.QGIV.transaction) ? data.QGIV.transaction : {};
 
         var recurringByFlag = transaction.recurring === true;


### PR DESCRIPTION
## Summary
- Reverts the temporary debug logging added in #494.
- We confirmed the payload shape from a real production donation: `event.detail.QGIV.contact` includes `email`, `firstName`, `lastName`, and `optedIn` (the newsletter opt-in checkbox), so no further investigation is needed.
- Follow-up PR will use `contact.optedIn` + `contact.email` to POST to a new `/api/donation-complete` route that adds opted-in donors to EmailOctopus (mirroring the existing `membership-complete.ts` pattern).

## Test plan
- [ ] Confirm `/donate` still tracks Monthly-donate/One-time-donate Plausible events after a test donation
- [ ] Confirm no debug UI/logging appears on the page