### PR TITLE
feat(donate): sync opted-in donors to EmailOctopus

### DIFF
--- a/src/pages/api/donation-complete.ts
+++ b/src/pages/api/donation-complete.ts
@@ -1,0 +1,112 @@
+import type { APIRoute } from "astro";
+import * as Sentry from "@sentry/astro";
+import { reportError } from "../../lib/report-error";
+import { getEnv } from "../../utils/getEnv";
+
+export const prerender = false;
+
+const ALLOWED_ORIGINS = [
+  "https://techforpalestine.org",
+  ...(import.meta.env.PROD ? [] : ["http://localhost:4321"]),
+];
+
+function isAllowedOrigin(origin: string | null): origin is string {
+  if (!origin) return false;
+  if (ALLOWED_ORIGINS.includes(origin)) return true;
+  return /\.website-aun\.pages\.dev$/.test(new URL(origin).hostname);
+}
+const EO_MEMBERS_LIST_URL =
+  "https://emailoctopus.com/api/1.6/lists/8adc2ed4-f798-11ef-b60f-115427c25a1c/contacts";
+const MAX_NAME_LENGTH = 200;
+
+function corsHeaders(origin: string) {
+  return {
+    "Access-Control-Allow-Origin": origin,
+    "Access-Control-Allow-Methods": "POST, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type",
+  } as const;
+}
+
+export const POST: APIRoute = async ({ request, locals }) => {
+  const origin = request.headers.get("Origin");
+  if (!isAllowedOrigin(origin)) {
+    return new Response(JSON.stringify({ message: "Forbidden" }), {
+      status: 403,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const ctx = (locals as { runtime?: { ctx?: { waitUntil: (p: Promise<unknown>) => void } } }).runtime?.ctx;
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return new Response(JSON.stringify({ message: "Invalid request body" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json", ...corsHeaders(origin) },
+    });
+  }
+
+  const { email, firstName, lastName } = body as Record<string, unknown>;
+
+  if (typeof email !== "string" || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+    return new Response(JSON.stringify({ message: "Invalid or missing email" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json", ...corsHeaders(origin) },
+    });
+  }
+
+  const safeFirst = typeof firstName === "string" ? firstName.slice(0, MAX_NAME_LENGTH) : "";
+  const safeLast = typeof lastName === "string" ? lastName.slice(0, MAX_NAME_LENGTH) : "";
+
+  const eoApiKey = getEnv("EO_API_KEY", locals);
+  const redacted = `[redacted]@${email.split("@")[1]}`;
+
+  try {
+    if (eoApiKey) {
+      const res = await fetch(EO_MEMBERS_LIST_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          api_key: eoApiKey,
+          email_address: email,
+          fields: { FirstName: safeFirst, LastName: safeLast },
+          tags: ["donor"],
+          status: "SUBSCRIBED",
+        }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        reportError(new Error(`EmailOctopus failed: ${res.status}`), {
+          context: "donation-complete eo",
+          email: redacted,
+          status: res.status,
+          body: data,
+        });
+      }
+    }
+
+    return new Response(JSON.stringify({ success: true }), {
+      status: 200,
+      headers: { "Content-Type": "application/json", ...corsHeaders(origin) },
+    });
+  } catch (error) {
+    reportError(error, { context: "donation-complete" });
+    ctx?.waitUntil(Promise.resolve(Sentry.flush(2000)));
+
+    return new Response(JSON.stringify({ message: "Failed to process request" }), {
+      status: 500,
+      headers: { "Content-Type": "application/json", ...corsHeaders(origin) },
+    });
+  }
+};
+
+export const OPTIONS: APIRoute = async ({ request }) => {
+  const origin = request.headers.get("Origin");
+  if (!isAllowedOrigin(origin)) {
+    return new Response(null, { status: 403 });
+  }
+  return new Response(null, { status: 200, headers: corsHeaders(origin) });
+};

--- a/src/pages/donate.astro
+++ b/src/pages/donate.astro
@@ -282,6 +282,7 @@ const isUK = country === "GB";
       document.addEventListener("QGIV.donationComplete", async function (event) {
         var data = (event instanceof CustomEvent && event.detail) ? event.detail : {};
         var transaction = (data.QGIV && data.QGIV.transaction) ? data.QGIV.transaction : {};
+        var contact = (data.QGIV && data.QGIV.contact) ? data.QGIV.contact : {};
 
         var recurringByFlag = transaction.recurring === true;
         var recurringByFrequency = typeof transaction.frequency === "string" &&
@@ -295,6 +296,18 @@ const isUK = country === "GB";
           await new Promise(function (resolve) {
             window.plausible(donationEvent, { props: props, callback: resolve });
           });
+        }
+
+        if (contact.optedIn === true && contact.email) {
+          fetch("/api/donation-complete", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              email: contact.email,
+              firstName: contact.firstName || "",
+              lastName: contact.lastName || "",
+            }),
+          }).catch(function () {});
         }
       });
 


### PR DESCRIPTION
## Summary
- Adds a new `/api/donation-complete` route (modeled on the existing `membership-complete.ts`) that adds a contact to EmailOctopus, tagged `"donor"`.
- Wires it up in `donate.astro`'s existing `QGIV.donationComplete` handler: when the donor checked the "I would like to get news and updates from Tech for Palestine!" opt-in checkbox in the QGiv form (`event.detail.QGIV.contact.optedIn === true`), fire-and-forget POST their email/first/last name to the new route.
- No Hub invite is sent for donors (that's membership-specific); this is EmailOctopus-only.
- Reuses the same EmailOctopus list as members (`8adc2ed4-f798-11ef-b60f-115427c25a1c`), just with a different tag, so no new env vars or list IDs are needed.

## Test plan
- [x] `pnpm build` passes
- [x] On a preview deploy, make a test donation via the QGiv embed with the opt-in checkbox checked, confirm the contact appears in EmailOctopus tagged `"donor"`
- [x] Make a test donation with the checkbox unchecked, confirm no EmailOctopus call is made
- [x] Confirm existing Plausible donation tracking still fires unchanged