### PR TITLE
Migrate /projects-new and /events-new to Tailwind design system

### DIFF
--- a/src/pages/contact-new.astro
+++ b/src/pages/contact-new.astro
@@ -6,7 +6,7 @@ const membershipLive = getEnv("MEMBERSHIP_LIVE", Astro.locals) === "true";
 ---
 
 <HomeLayout
-  title="Contact Us | Tech for Palestine"
+  title="Contact Us"
   description="Get in touch with Tech for Palestine — general questions, media inquiries, or request an endorsement for your campaign."
 >
   <HomeNavbar membershipLive={membershipLive} alwaysVisible />

--- a/src/pages/donate-2-new.astro
+++ b/src/pages/donate-2-new.astro
@@ -7,7 +7,7 @@ const membershipLive = getEnv("MEMBERSHIP_LIVE", Astro.locals) === "true";
 ---
 
 <HomeLayout
-  title="Donate - Tech for Palestine"
+  title="Donate"
   description="Support Tech for Palestine. Your donation helps us hire professionals, strengthen existing projects, and launch new initiatives for a free Palestine."
 >
   <HomeNavbar membershipLive={membershipLive} alwaysVisible />

--- a/src/pages/donate-new.astro
+++ b/src/pages/donate-new.astro
@@ -9,7 +9,7 @@ const isUK = country === "GB";
 ---
 
 <HomeLayout
-  title="Donate - Tech for Palestine"
+  title="Donate"
   description="Support Tech for Palestine. Your donation helps us strengthen existing projects and launch new initiatives for a free Palestine."
 >
   <HomeNavbar membershipLive={membershipLive} alwaysVisible />

--- a/src/pages/e4p-new.astro
+++ b/src/pages/e4p-new.astro
@@ -151,7 +151,7 @@ const founders = [
 ---
 
 <HomeLayout
-  title="Entrepreneurs for Palestine - Tech for Palestine"
+  title="Entrepreneurs for Palestine"
   description="Entrepreneurs for Palestine is a global community of founders and CEOs joining forces to stand up for what's right and make a difference for the Palestinian cause."
 >
   <HomeNavbar membershipLive={membershipLive} alwaysVisible />

--- a/src/pages/endorsements-new.astro
+++ b/src/pages/endorsements-new.astro
@@ -8,7 +8,7 @@ const membershipLive = getEnv("MEMBERSHIP_LIVE", Astro.locals) === "true";
 ---
 
 <HomeLayout
-  title="Endorsements | Tech for Palestine"
+  title="Endorsements"
   description="Request an endorsement from Tech for Palestine for your campaign or organization. Learn what we look for and how the review process works."
 >
   <HomeNavbar membershipLive={membershipLive} alwaysVisible />

--- a/src/pages/events-new.astro
+++ b/src/pages/events-new.astro
@@ -3,16 +3,13 @@ import { getEnv } from "../utils/getEnv";
 import HomeLayout from "../layouts/HomeLayout.astro";
 import HomeNavbar from "../components/home/HomeNavbar.astro";
 import Button from "../components/ui/Button.astro";
-import EventsComponent from "../components/Events.tsx";
+import EventsNewComponent from "../components/events/EventsNew";
 
 const membershipLive = getEnv("MEMBERSHIP_LIVE", Astro.locals) === "true";
-
-let events: any[] = [];
-let loading: boolean = true;
 ---
 
 <HomeLayout
-  title="Events - Tech for Palestine"
+  title="Events"
   description="Tech for Palestine events bring together builders, organizers, and allies to collaborate, share ideas, and take action in support of Palestinian liberation. Join our community webinars, workshops, and networking sessions."
 >
   <HomeNavbar membershipLive={membershipLive} alwaysVisible />
@@ -32,7 +29,7 @@ let loading: boolean = true;
     </section>
 
     <section class="bg-page">
-      <EventsComponent events={events} loading={loading} client:only="react" />
+      <EventsNewComponent client:only="react" />
     </section>
   </main>
 </HomeLayout>

--- a/src/pages/get-involved-new.astro
+++ b/src/pages/get-involved-new.astro
@@ -9,7 +9,7 @@ const membershipLive = getEnv("MEMBERSHIP_LIVE", Astro.locals) === "true";
 ---
 
 <HomeLayout
-  title="Get Involved - Tech for Palestine"
+  title="Get Involved"
   description="Join our mission-driven community building tools and projects for Palestinian liberation. Volunteer, mentor, build, and more."
 >
   <HomeNavbar membershipLive={membershipLive} alwaysVisible />

--- a/src/pages/ideas-new.astro
+++ b/src/pages/ideas-new.astro
@@ -31,7 +31,7 @@ const startedIdeas = rawIdeas.filter((i) => i.category === "started").map(mapIde
 ---
 
 <HomeLayout
-  title="Project Ideas - Tech for Palestine"
+  title="Project Ideas"
   description="Browse and lead project ideas that support Palestinian freedom. Tech for Palestine builds bold projects to support Palestinian advocacy and counter pro-Israel propaganda. Explore new ideas, existing projects, and initiatives that have already started."
 >
   <HomeNavbar membershipLive={membershipLive} alwaysVisible />

--- a/src/pages/legal-new.astro
+++ b/src/pages/legal-new.astro
@@ -7,7 +7,7 @@ const membershipLive = getEnv("MEMBERSHIP_LIVE", Astro.locals) === "true";
 ---
 
 <HomeLayout
-  title="Financial & Legal Notice — Tech for Palestine"
+  title="Financial & Legal Notice"
   description="Tech for Palestine's legal structure, financial transparency, and compliance information."
 >
   <HomeNavbar membershipLive={membershipLive} alwaysVisible />

--- a/src/pages/london-gathering-new.astro
+++ b/src/pages/london-gathering-new.astro
@@ -38,7 +38,7 @@ const stats = [
 ---
 
 <HomeLayout
-  title="Tech for Palestine Gathering - London"
+  title="Gathering - London"
   description="A full day event for T4P community members with workshops and networking opportunities. November 8, 2025 at Palestine House, London."
 >
   <HomeNavbar membershipLive={membershipLive} alwaysVisible />

--- a/src/pages/media-new.astro
+++ b/src/pages/media-new.astro
@@ -117,7 +117,7 @@ const darkAssets = [
 ---
 
 <HomeLayout
-  title="Media & Press — Tech for Palestine"
+  title="Media & Press"
   description="Interviews, news coverage, press kit, and media resources for Tech for Palestine."
 >
   <HomeNavbar membershipLive={membershipLive} alwaysVisible />

--- a/src/pages/membership-new.astro
+++ b/src/pages/membership-new.astro
@@ -45,7 +45,7 @@ const teams = [
 ---
 
 <HomeLayout
-  title="Membership - Tech for Palestine"
+  title="Membership"
   description="Join the coalition working on impactful initiatives for Palestinian liberation. Browse activism initiatives looking for your skills, or start an initiative of your own with T4P support."
 >
   <HomeNavbar membershipLive={membershipLive} alwaysVisible />

--- a/src/pages/mentorship-new.astro
+++ b/src/pages/mentorship-new.astro
@@ -9,7 +9,7 @@ const membershipLive = getEnv("MEMBERSHIP_LIVE", Astro.locals) === "true";
 ---
 
 <HomeLayout
-  title="Mentorship - Tech for Palestine"
+  title="Mentorship"
   description="Support T4P Incubator projects with expertise and guidance. Become a mentor and help Palestinian tech projects find product-market fit."
 >
   <HomeNavbar membershipLive={membershipLive} alwaysVisible />

--- a/src/pages/privacy-policy-new.astro
+++ b/src/pages/privacy-policy-new.astro
@@ -7,7 +7,7 @@ const membershipLive = getEnv("MEMBERSHIP_LIVE", Astro.locals) === "true";
 ---
 
 <HomeLayout
-  title="Privacy Policy — Tech for Palestine"
+  title="Privacy Policy"
   description="How Tech for Palestine collects, uses, and protects your personal information."
 >
   <HomeNavbar membershipLive={membershipLive} alwaysVisible />

--- a/src/pages/projects-new.astro
+++ b/src/pages/projects-new.astro
@@ -3,16 +3,13 @@ import { getEnv } from "../utils/getEnv";
 import HomeLayout from "../layouts/HomeLayout.astro";
 import HomeNavbar from "../components/home/HomeNavbar.astro";
 import Button from "../components/ui/Button.astro";
-import ProjectsNewComponent from "../components/ProjectsNew.tsx";
+import ProjectsDirectory from "../components/projects/ProjectsDirectory";
 
 const membershipLive = getEnv("MEMBERSHIP_LIVE", Astro.locals) === "true";
-
-let projects: any[] = [];
-let loading: boolean = true;
 ---
 
 <HomeLayout
-  title="Incubator Projects - Tech for Palestine"
+  title="Incubator Projects"
   description="Explore the projects in the Tech for Palestine Incubator. We help pro-Palestine advocates build, grow, and scale technical projects that support Palestinian freedom and counter pro-Israel propaganda."
 >
   <HomeNavbar membershipLive={membershipLive} alwaysVisible />
@@ -21,18 +18,31 @@ let loading: boolean = true;
     <section class="bg-page px-6 pt-14 pb-10 min-[810px]:px-10 min-[810px]:pt-20 min-[810px]:pb-14">
       <div class="mx-auto max-w-[1400px]">
         <div class="page-animate">
-          <p class="ts-overline mb-5 text-ink-secondary">Tech for Palestine</p>
+          <p class="ts-overline mb-5 text-ink-secondary">The Incubator</p>
           <h1 class="ts-editorial mb-5 text-ink">Incubator Projects</h1>
           <p class="ts-body-large max-w-[65ch] text-ink-secondary">
-            What is the incubator? <a href="/incubator" class="text-brand underline underline-offset-2 hover:text-brand-hover">Learn more</a>
+            Every project below was built and led by volunteers who turned frustration into action. Explore what the movement has built, then help lead the next one.
           </p>
+          <div class="mt-8 flex flex-wrap gap-3">
+            <Button
+              href="https://techforpalestine.org/project-application-form"
+              variant="primary"
+              size="md"
+              arrow
+            >
+              Apply now
+            </Button>
+            <Button href="/incubator-new" variant="ghost" size="md">
+              About the Incubator
+            </Button>
+          </div>
         </div>
         <div class="mt-10 h-px w-full bg-ink-divider min-[810px]:mt-14" />
       </div>
     </section>
 
     <section class="bg-page">
-      <ProjectsNewComponent projects={projects} loading={loading} client:only="react" />
+      <ProjectsDirectory client:only="react" />
     </section>
 
     <section class="bg-sand px-6 py-14 min-[810px]:px-10 min-[810px]:py-20">

--- a/src/pages/terms-new.astro
+++ b/src/pages/terms-new.astro
@@ -7,7 +7,7 @@ const membershipLive = getEnv("MEMBERSHIP_LIVE", Astro.locals) === "true";
 ---
 
 <HomeLayout
-  title="Terms & Conditions — Tech for Palestine"
+  title="Terms & Conditions"
   description="Terms of Service governing your use of Tech for Palestine's website and services."
 >
   <HomeNavbar membershipLive={membershipLive} alwaysVisible />

--- a/src/pages/tools-new.astro
+++ b/src/pages/tools-new.astro
@@ -104,7 +104,7 @@ const tools = [
 ---
 
 <HomeLayout
-  title="Tools - Tech for Palestine"
+  title="Tools"
   description="A growing list of tools built by the movement to support advocacy for Palestinian liberation — from ethical AI and news coverage to boycott tools, protest maps, and accountability databases."
 >
   <HomeNavbar membershipLive={membershipLive} alwaysVisible />

--- a/src/pages/volunteer-new.astro
+++ b/src/pages/volunteer-new.astro
@@ -9,7 +9,7 @@ const membershipLive = getEnv("MEMBERSHIP_LIVE", Astro.locals) === "true";
 ---
 
 <HomeLayout
-  title="Get Involved - Tech for Palestine"
+  title="Get Involved"
   description="Join the Tech for Palestine volunteer community. Apply your skills to projects that amplify Palestinian voices and support the movement for liberation."
 >
   <HomeNavbar membershipLive={membershipLive} alwaysVisible />


### PR DESCRIPTION
## Summary
- `/projects-new` now renders `ProjectsDirectory` (Tailwind, `ts-*` tokens, slide-in `ProjectDrawer`) instead of the leftover MUI `ProjectsNew.tsx`, matching the pattern already shipped on `/ideas-new` (`IdeasWithTabsNew`).
- `/events-new` now renders `EventsNew` (Tailwind hero/lineup/archive layout) instead of the leftover MUI `Events.tsx`. Both replacement components already existed in the codebase but were unwired.
- Refreshed the `/projects-new` hero copy (overline, headline, subtitle) and added the missing primary/ghost CTA buttons (`Apply now` / `About the Incubator` → `/incubator-new`), matching the hero pattern on `/ideas-new`.
- Stripped the redundant "- Tech for Palestine" suffix from page `<title>` across the `-new` pages (homepage titles `home-new`/`index-new` intentionally left as-is; `london-gathering-new` title updated per explicit direction).

## Test plan
- [x] `pnpm check` passes with 0 errors
- [x] Load `/projects-new`: search, tag filter, featured band, and card click → slide-in drawer with CTAs/impact/leader/socials/tags
- [x] Load `/events-new`: hero event, lineup strip, past-events archive, register/recording links
- [ ] Spot-check a few other `-new` pages' browser tab titles for the suffix removal