### PR TITLE
fix: exclude endorsements-new page from sitemap

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -90,6 +90,7 @@ export default defineConfig({
           "/privacy-policy-new/",
           "/events-new/",
           "/home-new/",
+          "/endorsements-new/",
         ];
         return !exclude.some((path) => page.endsWith(path));
       },


### PR DESCRIPTION
## Summary
- `src/pages/endorsements-new.astro` was the only `-new`/`-2`/`-temp` page missing from the sitemap `filter` exclude list in `astro.config.mjs`, leaving it crawlable/indexable despite being an unlinked redesign page.
- Adds `"/endorsements-new/"` to the exclude array, matching the existing convention documented in `CLAUDE.md`.

Closes #503

## Test plan
- [x] `pnpm build` and confirmed `dist/sitemap-0.xml` no longer contains `/endorsements-new`
- [x] Confirmed all other previously-excluded `-new` pages remain excluded (no regression)
- [x] Reviewed via `/code-review` (Standards + Spec axes) — no findings on either axis