### PR TITLE
fix(seo): SEO/GEO/AEO audit fixes for -new draft pages, part 3

### DIFF
--- a/src/layouts/HomeLayout.astro
+++ b/src/layouts/HomeLayout.astro
@@ -13,6 +13,11 @@ interface Props {
   image?: string;
   noindex?: boolean;
   canonicalUrl?: string;
+  // Extra JSON-LD properties to merge into the sitewide NonprofitOrganization
+  // node (e.g. a page-specific contactPoint or potentialAction). Pages must
+  // not emit their own NonprofitOrganization script sharing the same @id —
+  // separate <script> tags aren't reliably merged by structured-data parsers.
+  organizationSchemaExtra?: Record<string, unknown>;
 }
 
 const {
@@ -21,6 +26,7 @@ const {
   image = "https://techforpalestine.org/t4p-social-logo.png",
   noindex = false,
   canonicalUrl: canonicalUrlOverride,
+  organizationSchemaExtra,
 } = Astro.props;
 
 const membershipLive = getEnv("MEMBERSHIP_LIVE", Astro.locals) === "true";
@@ -41,6 +47,7 @@ const organizationSchema = {
   "@context": "https://schema.org",
   "@type": "NonprofitOrganization",
   "@id": "https://techforpalestine.org/#organization",
+  ...organizationSchemaExtra,
   name: "Tech for Palestine",
   url: "https://techforpalestine.org",
   logo: "https://techforpalestine.org/t4p-social-logo.png",

--- a/src/pages/about-new.astro
+++ b/src/pages/about-new.astro
@@ -185,6 +185,8 @@ const founderSchema = {
               src="/images/new-homepage/why/paul.webp"
               alt="Paul Biggar, founder of Tech for Palestine"
               class="w-full rounded-[20px] border border-butter object-cover"
+              width="1254"
+              height="1254"
               loading="lazy"
               decoding="async"
             />
@@ -301,6 +303,8 @@ const founderSchema = {
           src="/gaza-children-playing-ocean.jpg"
           alt="Palestinian children playing joyfully in ocean waves at sunset on Gaza's Mediterranean coastline"
           class="aspect-[5/2] w-full rounded-lg object-cover"
+          width="900"
+          height="603"
           loading="lazy"
           decoding="async"
         />

--- a/src/pages/contact-new.astro
+++ b/src/pages/contact-new.astro
@@ -9,22 +9,14 @@ const membershipLive = getEnv("MEMBERSHIP_LIVE", Astro.locals) === "true";
   title="Contact Us | Tech for Palestine"
   description="Get in touch with Tech for Palestine — general questions, media inquiries, or request an endorsement for your campaign."
   noindex={true}
+  organizationSchemaExtra={{
+    contactPoint: {
+      "@type": "ContactPoint",
+      contactType: "customer support",
+      email: "contact@techforpalestine.org",
+    },
+  }}
 >
-  <Fragment slot="head">
-    <script
-      type="application/ld+json"
-      set:html={JSON.stringify({
-        "@context": "https://schema.org",
-        "@type": "NonprofitOrganization",
-        "@id": "https://techforpalestine.org/#organization",
-        contactPoint: {
-          "@type": "ContactPoint",
-          contactType: "customer support",
-          email: "contact@techforpalestine.org",
-        },
-      })}
-    />
-  </Fragment>
   <HomeNavbar membershipLive={membershipLive} alwaysVisible />
   <main class="pt-20">
     <section class="bg-sand px-6 py-14 min-[810px]:px-10 min-[810px]:py-20">
@@ -48,6 +40,7 @@ const membershipLive = getEnv("MEMBERSHIP_LIVE", Astro.locals) === "true";
           <div class="page-animate rounded-xl border border-butter bg-cream p-8">
             <div class="mb-4 inline-flex h-12 w-12 items-center justify-center rounded-lg bg-sand">
               <svg
+                aria-hidden="true"
                 xmlns="http://www.w3.org/2000/svg"
                 fill="none"
                 viewBox="0 0 24 24"
@@ -79,6 +72,7 @@ const membershipLive = getEnv("MEMBERSHIP_LIVE", Astro.locals) === "true";
           <div class="page-animate rounded-xl border border-butter bg-cream p-8">
             <div class="mb-4 inline-flex h-12 w-12 items-center justify-center rounded-lg bg-sand">
               <svg
+                aria-hidden="true"
                 xmlns="http://www.w3.org/2000/svg"
                 fill="none"
                 viewBox="0 0 24 24"
@@ -110,6 +104,7 @@ const membershipLive = getEnv("MEMBERSHIP_LIVE", Astro.locals) === "true";
           <div class="page-animate rounded-xl border border-butter bg-cream p-8">
             <div class="mb-4 inline-flex h-12 w-12 items-center justify-center rounded-lg bg-sand">
               <svg
+                aria-hidden="true"
                 xmlns="http://www.w3.org/2000/svg"
                 fill="none"
                 viewBox="0 0 24 24"
@@ -140,6 +135,7 @@ const membershipLive = getEnv("MEMBERSHIP_LIVE", Astro.locals) === "true";
           <div class="page-animate rounded-xl border border-butter bg-cream p-8">
             <div class="mb-4 inline-flex h-12 w-12 items-center justify-center rounded-lg bg-sand">
               <svg
+                aria-hidden="true"
                 xmlns="http://www.w3.org/2000/svg"
                 fill="none"
                 viewBox="0 0 24 24"

--- a/src/pages/donate-2-new.astro
+++ b/src/pages/donate-2-new.astro
@@ -13,23 +13,16 @@ const membershipLive = getEnv("MEMBERSHIP_LIVE", Astro.locals) === "true";
   description="Alternate donation form for Tech for Palestine. Use this page if the primary donate form doesn't load in your browser."
   noindex={true}
   canonicalUrl="https://techforpalestine.org/donate"
+  organizationSchemaExtra={{
+    potentialAction: {
+      "@type": "DonateAction",
+      name: "Donate to Tech for Palestine",
+      description:
+        "Your donation helps us hire professionals, strengthen existing projects, and launch new initiatives for a free Palestine.",
+      target: "https://techforpalestine.org/donate-2-new",
+    },
+  }}
 >
-  <Fragment slot="head">
-    <script
-      type="application/ld+json"
-      set:html={JSON.stringify({
-        "@context": "https://schema.org",
-        "@type": "NonprofitOrganization",
-        "@id": "https://techforpalestine.org/#organization",
-        potentialAction: {
-          "@type": "DonateAction",
-          name: "Donate to Tech for Palestine",
-          description:
-            "Your donation helps us hire professionals, strengthen existing projects, and launch new initiatives for a free Palestine.",
-        },
-      })}
-    />
-  </Fragment>
   <HomeNavbar membershipLive={membershipLive} alwaysVisible />
 
   <main class="pt-20">

--- a/src/pages/donate-new.astro
+++ b/src/pages/donate-new.astro
@@ -8,29 +8,26 @@ import HomeNavbar from "../components/home/HomeNavbar.astro";
 const membershipLive = getEnv("MEMBERSHIP_LIVE", Astro.locals) === "true";
 const country = Astro.request.headers.get("cf-ipcountry") || "UNKNOWN";
 const isUK = country === "GB";
+// Server-rendered fallback variant (no A/B randomization) so the donation
+// form is present in the initial HTML for non-JS clients and crawlers —
+// the client-side A/B test below still overrides this for real visitors.
+const defaultFormId = isUK ? "form-validaid-link" : "form-qgiv-link";
 ---
 
 <HomeLayout
-  title="Donate | Tech for Palestine"
-  description="Support Tech for Palestine. Your donation helps us strengthen existing projects and launch new initiatives for a free Palestine."
+  title="Donate to Tech for Palestine | Support Our Work"
+  description="Support Tech for Palestine, a 501(c)(3) nonprofit. Your donation helps us strengthen existing projects and launch new initiatives for a free Palestine."
   noindex={true}
+  organizationSchemaExtra={{
+    potentialAction: {
+      "@type": "DonateAction",
+      name: "Donate to Tech for Palestine",
+      description:
+        "Your donation helps us strengthen existing projects and launch new initiatives for a free Palestine.",
+      target: "https://techforpalestine.org/donate-new",
+    },
+  }}
 >
-  <Fragment slot="head">
-    <script
-      type="application/ld+json"
-      set:html={JSON.stringify({
-        "@context": "https://schema.org",
-        "@type": "NonprofitOrganization",
-        "@id": "https://techforpalestine.org/#organization",
-        potentialAction: {
-          "@type": "DonateAction",
-          name: "Donate to Tech for Palestine",
-          description:
-            "Your donation helps us strengthen existing projects and launch new initiatives for a free Palestine.",
-        },
-      })}
-    />
-  </Fragment>
   <HomeNavbar membershipLive={membershipLive} alwaysVisible />
 
   <main class="pt-20">
@@ -75,7 +72,7 @@ const isUK = country === "GB";
               </div>
 
               <!-- Variant B Non-UK: Qgiv + link to ValidAid -->
-              <div id="form-qgiv-link" hidden>
+              <div id="form-qgiv-link" hidden={defaultFormId !== "form-qgiv-link"}>
                 <p class="ts-body-small mb-4 text-ink-secondary">
                   If you are in the UK, <a
                     href="?variant=validaid"
@@ -94,7 +91,7 @@ const isUK = country === "GB";
               </div>
 
               <!-- Variant B UK: ValidAid + link to Qgiv -->
-              <div id="form-validaid-link" hidden>
+              <div id="form-validaid-link" hidden={defaultFormId !== "form-validaid-link"}>
                 <p class="ts-body-small mb-4 text-ink-secondary">
                   Not in the UK? <a
                     href="?variant=qgiv"
@@ -308,6 +305,14 @@ const isUK = country === "GB";
         trackingVariant = "qgiv + link";
       }
     }
+
+    // One variant is server-rendered visible (non-JS fallback) regardless of
+    // which variant this client ends up assigned to, so hide all three before
+    // revealing the chosen one to avoid showing two forms at once.
+    ["form-qgiv-only", "form-qgiv-link", "form-validaid-link"].forEach((id) => {
+      const el = document.getElementById(id);
+      if (el) el.style.display = "none";
+    });
 
     const targetForm = document.getElementById(formToShow);
     if (targetForm) {

--- a/src/pages/e4p-new.astro
+++ b/src/pages/e4p-new.astro
@@ -369,6 +369,8 @@ const peopleSchema = [...testimonials, ...founders].map((person) => ({
                     src={f.image}
                     alt={f.name}
                     class="founder-avatar mb-4 h-20 w-20 rounded-full object-cover min-[810px]:h-24 min-[810px]:w-24"
+                    width="96"
+                    height="96"
                     loading="lazy"
                     decoding="async"
                   />

--- a/src/pages/get-involved-new.astro
+++ b/src/pages/get-involved-new.astro
@@ -10,9 +10,11 @@ const membershipLive = getEnv("MEMBERSHIP_LIVE", Astro.locals) === "true";
 const webPageSchema = {
   "@context": "https://schema.org",
   "@type": "WebPage",
-  name: "Get Involved | Tech for Palestine",
+  "@id": "https://techforpalestine.org/get-involved-new",
+  url: "https://techforpalestine.org/get-involved-new",
+  name: "Get Involved with Tech for Palestine | Volunteer & More",
   description:
-    "Join our mission-driven community building tools and projects for Palestinian liberation. Volunteer, mentor, build, and more.",
+    "Join our mission-driven community building tools and projects for Palestinian liberation. Volunteer, mentor, contribute your skills, or help lead a project.",
   isPartOf: {
     "@type": "NonprofitOrganization",
     "@id": "https://techforpalestine.org/#organization",
@@ -21,8 +23,8 @@ const webPageSchema = {
 ---
 
 <HomeLayout
-  title="Get Involved | Tech for Palestine"
-  description="Join our mission-driven community building tools and projects for Palestinian liberation. Volunteer, mentor, build, and more."
+  title="Get Involved with Tech for Palestine | Volunteer & More"
+  description="Join our mission-driven community building tools and projects for Palestinian liberation. Volunteer, mentor, contribute your skills, or help lead a project."
   noindex={true}
 >
   <Fragment slot="head">
@@ -57,6 +59,7 @@ const webPageSchema = {
           <div class="gi-animate rounded-xl border border-butter bg-cream p-8">
             <div class="mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-butter">
               <svg
+                aria-hidden="true"
                 xmlns="http://www.w3.org/2000/svg"
                 fill="none"
                 viewBox="0 0 24 24"
@@ -89,6 +92,7 @@ const webPageSchema = {
           <div class="gi-animate rounded-xl border border-butter bg-cream p-8">
             <div class="mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-butter">
               <svg
+                aria-hidden="true"
                 xmlns="http://www.w3.org/2000/svg"
                 fill="none"
                 viewBox="0 0 24 24"
@@ -126,6 +130,7 @@ const webPageSchema = {
           <div class="gi-animate rounded-xl border border-butter bg-cream p-8">
             <div class="mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-butter">
               <svg
+                aria-hidden="true"
                 xmlns="http://www.w3.org/2000/svg"
                 fill="none"
                 viewBox="0 0 24 24"
@@ -165,6 +170,7 @@ const webPageSchema = {
           <div class="gi-animate rounded-xl border border-butter bg-cream p-8">
             <div class="mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-butter">
               <svg
+                aria-hidden="true"
                 xmlns="http://www.w3.org/2000/svg"
                 fill="none"
                 viewBox="0 0 24 24"
@@ -190,6 +196,7 @@ const webPageSchema = {
           <div class="gi-animate rounded-xl border border-butter bg-cream p-8">
             <div class="mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-butter">
               <svg
+                aria-hidden="true"
                 xmlns="http://www.w3.org/2000/svg"
                 fill="none"
                 viewBox="0 0 24 24"
@@ -217,6 +224,7 @@ const webPageSchema = {
           <div class="gi-animate rounded-xl border border-butter bg-cream p-8">
             <div class="mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-butter">
               <svg
+                aria-hidden="true"
                 xmlns="http://www.w3.org/2000/svg"
                 fill="none"
                 viewBox="0 0 24 24"
@@ -242,6 +250,7 @@ const webPageSchema = {
           <div class="gi-animate rounded-xl border border-butter bg-cream p-8">
             <div class="mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-butter">
               <svg
+                aria-hidden="true"
                 xmlns="http://www.w3.org/2000/svg"
                 fill="none"
                 viewBox="0 0 24 24"

--- a/src/pages/ideas-new.astro
+++ b/src/pages/ideas-new.astro
@@ -17,11 +17,20 @@ try {
 
 const mapIdea = (idea: any) => {
   const plainText = idea.description.map((s: any) => s.plain_text).join("");
+  // Truncate at the last word boundary within the limit rather than a hard
+  // character cut, so structured-data descriptions read as clean sentence
+  // fragments instead of stopping mid-word.
+  let excerpt = plainText;
+  if (plainText.length > 150) {
+    const truncated = plainText.slice(0, 150);
+    const lastSpace = truncated.lastIndexOf(" ");
+    excerpt = (lastSpace > 0 ? truncated.slice(0, lastSpace) : truncated) + "...";
+  }
   return {
     id: idea.id,
     data: { title: idea.name, tags: [] },
     richTextDescription: idea.description,
-    excerpt: plainText.substring(0, 150) + (plainText.length > 150 ? "..." : ""),
+    excerpt,
   };
 };
 
@@ -91,6 +100,7 @@ const ideasListSchema = allIdeas.length > 0 && {
     </section>
 
     <section class="bg-page pt-10 min-[810px]:pt-12">
+      <h2 class="sr-only">Browse ideas</h2>
       <IdeasWithTabsNew
         newIdeas={newIdeas}
         existingIdeas={existingIdeas}

--- a/src/pages/incubator-new.astro
+++ b/src/pages/incubator-new.astro
@@ -219,6 +219,8 @@ const membershipLive = getEnv("MEMBERSHIP_LIVE", Astro.locals) === "true";
           src="/happy-kids.jpg"
           alt="Palestinian children smiling together"
           class="aspect-[5/2] w-full rounded-lg object-cover"
+          width="2048"
+          height="1365"
           loading="lazy"
           decoding="async"
         />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,6 +2,17 @@
 import Layout from "../layouts/Layout.astro";
 import SignUpForm from "../structures/SignUpForm.astro";
 import "../styles/base.css";
+
+// Search/AI crawlers must never be enrolled in the client-side A/B redirect:
+// home-new is noindex, and a crawler that randomly lands there (via
+// location.replace) makes Google's indexing signal for "/" — the site's most
+// important URL — non-deterministic across crawls. Bots always get the
+// stable, indexable content on this page.
+const userAgent = Astro.request.headers.get("user-agent") || "";
+const isBot =
+  /bot|crawl|spider|slurp|facebookexternalhit|GPTBot|ChatGPT|CCBot|Claude-Web|ClaudeBot|PerplexityBot|anthropic|Applebot|ia_archiver/i.test(
+    userAgent
+  );
 ---
 
 <Layout
@@ -9,8 +20,9 @@ import "../styles/base.css";
   description="A coalition of thousands of founders, engineers, product marketers, investors and other professionals working in support of Palestinian liberation. The T4P Incubator helps pro-Palestine advocates build, grow, and scale their work towards a Free Palestine."
   image="https://techforpalestine.org/happy-kids.jpg"
 >
-  <script is:inline slot="head">
+  <script is:inline slot="head" define:vars={{ isBot }}>
     (function () {
+      if (isBot) return;
       try {
         var key = "ab-homepage-variant";
         var v = localStorage.getItem(key);

--- a/src/pages/legal-new.astro
+++ b/src/pages/legal-new.astro
@@ -11,9 +11,15 @@ const pageDescription =
 const webPageSchema = {
   "@context": "https://schema.org",
   "@type": "WebPage",
+  "@id": "https://techforpalestine.org/legal-new",
+  url: "https://techforpalestine.org/legal-new",
   name: pageTitle,
   description: pageDescription,
   dateModified: "2025-08-05",
+  publisher: {
+    "@type": "NonprofitOrganization",
+    "@id": "https://techforpalestine.org/#organization",
+  },
 };
 ---
 

--- a/src/pages/media-new.astro
+++ b/src/pages/media-new.astro
@@ -164,31 +164,28 @@ const darkAssets = [
   { label: "Mark Dark", file: "/logos/Mark-dark.png" },
 ];
 
-const pressSchema = {
-  "@context": "https://schema.org",
-  "@type": "NonprofitOrganization",
-  "@id": "https://techforpalestine.org/#organization",
-  subjectOf: [leadArticle, ...articles].map((a) => ({
-    "@type": "NewsArticle",
-    headline: a.headline,
-    url: a.url,
-    datePublished: toIsoDate(a.date),
-    publisher: {
-      "@type": "Organization",
-      name: a.publication,
-    },
-  })),
-};
+// Mentions rather than NewsArticle: these articles are hosted on third-party
+// publications' own domains, not this page, so NewsArticle (which expects an
+// `author` and describes content published at this URL) doesn't apply.
+const pressMentions = [leadArticle, ...articles].map((a) => ({
+  "@type": "CreativeWork",
+  headline: a.headline,
+  url: a.url,
+  datePublished: toIsoDate(a.date),
+  publisher: {
+    "@type": "Organization",
+    name: a.publication,
+  },
+}));
 ---
 
 <HomeLayout
-  title="Media & Press | Tech for Palestine"
-  description="Interviews, news coverage, press kit, and media resources for Tech for Palestine."
+  title="Media & Press Coverage | Tech for Palestine"
+  description="Press coverage, interviews, and media resources for Tech for Palestine — featured by TechCrunch, Al Jazeera, The Guardian, and more."
+  image="https://techforpalestine.org/images/press/ssir-tech-against-genocide.jpg"
   noindex={true}
+  organizationSchemaExtra={{ mentions: pressMentions }}
 >
-  <Fragment slot="head">
-    <script type="application/ld+json" set:html={JSON.stringify(pressSchema)} />
-  </Fragment>
   <HomeNavbar membershipLive={membershipLive} alwaysVisible />
 
   <main class="pt-20">

--- a/src/pages/membership-new.astro
+++ b/src/pages/membership-new.astro
@@ -60,7 +60,7 @@ const teams = [
 ---
 
 <HomeLayout
-  title="Membership | Tech for Palestine"
+  title="Become a Member of Tech for Palestine | Support Our Mission"
   description="Join the coalition working on initiatives for Palestinian liberation. Browse activism projects looking for your skills, or start your own with T4P support."
   noindex={true}
 >
@@ -104,7 +104,9 @@ const teams = [
           src="/images/membership-hero.jpg"
           alt="Tech for Palestine community members applauding at an event"
           class="aspect-[16/6] w-full rounded-[20px] object-cover [object-position:center_30%]"
-          loading="lazy"
+          width="2048"
+          height="1365"
+          loading="eager"
           decoding="async"
         />
       </div>

--- a/src/pages/mentorship-new.astro
+++ b/src/pages/mentorship-new.astro
@@ -9,8 +9,8 @@ const membershipLive = getEnv("MEMBERSHIP_LIVE", Astro.locals) === "true";
 ---
 
 <HomeLayout
-  title="Mentorship | Tech for Palestine"
-  description="Support T4P Incubator projects with expertise and guidance. Become a mentor and help Palestinian tech projects find product-market fit."
+  title="Mentorship Program | Tech for Palestine Incubator"
+  description="Support T4P Incubator projects with expertise and guidance. Become a volunteer mentor and help Palestinian advocacy tech projects find product-market fit."
   noindex={true}
 >
   <HomeNavbar membershipLive={membershipLive} alwaysVisible />

--- a/src/pages/privacy-policy-new.astro
+++ b/src/pages/privacy-policy-new.astro
@@ -7,13 +7,19 @@ const membershipLive = getEnv("MEMBERSHIP_LIVE", Astro.locals) === "true";
 
 const pageTitle = "Privacy Policy";
 const pageDescription =
-  "How Tech for Palestine collects, uses, and protects your personal information.";
+  "How Tech for Palestine, a 501(c)(3) nonprofit, collects, uses, shares, and protects the personal information of volunteers, donors, and website visitors.";
 const webPageSchema = {
   "@context": "https://schema.org",
   "@type": "WebPage",
+  "@id": "https://techforpalestine.org/privacy-policy-new",
+  url: "https://techforpalestine.org/privacy-policy-new",
   name: pageTitle,
   description: pageDescription,
   dateModified: "2025-08-05",
+  publisher: {
+    "@type": "NonprofitOrganization",
+    "@id": "https://techforpalestine.org/#organization",
+  },
 };
 ---
 

--- a/src/pages/projects-new.astro
+++ b/src/pages/projects-new.astro
@@ -56,11 +56,17 @@ try {
 const projectListSchema = projects.length > 0 && {
   "@context": "https://schema.org",
   "@type": "ItemList",
+  numberOfItems: projects.length,
   itemListElement: projects.slice(0, 50).map((project, index) => ({
     "@type": "ListItem",
     position: index + 1,
-    name: project.name,
-    url: project.websiteUrl || undefined,
+    item: {
+      "@type": "SoftwareApplication",
+      name: project.name,
+      description: project.description || undefined,
+      url: project.websiteUrl || undefined,
+      image: project.logoUrl || undefined,
+    },
   })),
 };
 ---
@@ -106,6 +112,7 @@ const projectListSchema = projects.length > 0 && {
     </section>
 
     <section class="bg-page">
+      <h2 class="sr-only">Browse projects</h2>
       <ProjectsDirectory initialProjects={projects} initialTags={tags} client:load />
     </section>
 

--- a/src/pages/team-new.astro
+++ b/src/pages/team-new.astro
@@ -74,6 +74,7 @@ const peopleSchema = [...board, ...staff].map((member) => ({
   "@type": "Person",
   name: member.name,
   jobTitle: member.role,
+  image: new URL(member.image, "https://techforpalestine.org").toString(),
   worksFor: {
     "@type": "NonprofitOrganization",
     "@id": "https://techforpalestine.org/#organization",
@@ -84,6 +85,7 @@ const peopleSchema = [...board, ...staff].map((member) => ({
 <HomeLayout
   title="Team & Board | Tech for Palestine"
   description="Meet the dedicated leaders guiding Tech for Palestine's mission to support Palestinian liberation through technology and advocacy."
+  image="https://techforpalestine.org/paul-biggar.webp"
   noindex={true}
 >
   <Fragment slot="head">

--- a/src/pages/terms-new.astro
+++ b/src/pages/terms-new.astro
@@ -7,13 +7,19 @@ const membershipLive = getEnv("MEMBERSHIP_LIVE", Astro.locals) === "true";
 
 const pageTitle = "Terms & Conditions";
 const pageDescription =
-  "Terms of Service governing your use of Tech for Palestine's website and services.";
+  "Terms of Service governing your use of Tech for Palestine's website, incubator application portal, and related advocacy and community services.";
 const webPageSchema = {
   "@context": "https://schema.org",
   "@type": "WebPage",
+  "@id": "https://techforpalestine.org/terms-new",
+  url: "https://techforpalestine.org/terms-new",
   name: pageTitle,
   description: pageDescription,
   dateModified: "2025-08-05",
+  publisher: {
+    "@type": "NonprofitOrganization",
+    "@id": "https://techforpalestine.org/#organization",
+  },
 };
 ---
 
@@ -122,6 +128,12 @@ const webPageSchema = {
                   >Privacy Policy</a
                 > (which is incorporated herein by reference). If you do not agree with any part of these
                 Terms or our Privacy Policy, you must not use our Services.
+              </p>
+              <p class="ts-body leading-relaxed text-ink-secondary">
+                For our full financial and legal disclosures, including our EIN and 501(c)(3)
+                status, see our <a href="/legal-new" class="text-brand hover:underline"
+                  >Financial &amp; Legal Notice</a
+                >.
               </p>
               <p class="ts-body leading-relaxed text-ink-secondary">
                 Please read these Terms carefully. They constitute a legally binding agreement

--- a/src/pages/tools-new.astro
+++ b/src/pages/tools-new.astro
@@ -102,15 +102,20 @@ const tools = [
   },
 ];
 
+const allTools = [...featured, ...tools];
 const toolsItemListSchema = {
   "@context": "https://schema.org",
   "@type": "ItemList",
-  itemListElement: [...featured, ...tools].map((tool, index) => ({
+  numberOfItems: allTools.length,
+  itemListElement: allTools.map((tool, index) => ({
     "@type": "ListItem",
     position: index + 1,
-    name: tool.name,
-    description: tool.desc,
-    url: tool.link,
+    item: {
+      "@type": "SoftwareApplication",
+      name: tool.name,
+      description: tool.desc,
+      url: tool.link,
+    },
   })),
 };
 ---
@@ -144,7 +149,7 @@ const toolsItemListSchema = {
 
     <section class="bg-page px-6 pb-12 min-[810px]:px-10">
       <div class="mx-auto max-w-[1400px]">
-        <p class="page-animate ts-overline mb-4 text-ink-secondary">Featured</p>
+        <h2 class="page-animate ts-overline mb-4 text-ink-secondary">Featured</h2>
         <div class="page-animate grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {
             featured.map((tool) => (
@@ -191,7 +196,7 @@ const toolsItemListSchema = {
 
     <section class="bg-page px-6 pb-14 min-[810px]:px-10 min-[810px]:pb-20">
       <div class="mx-auto max-w-[1400px]">
-        <p class="page-animate ts-overline mb-4 text-ink-secondary">More tools</p>
+        <h2 class="page-animate ts-overline mb-4 text-ink-secondary">More tools</h2>
         <div class="page-animate grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {
             tools.map((tool) => (


### PR DESCRIPTION
## Summary
Follow-up to #505, #506, #507 — a full re-audit of all 24 `-new` draft pages (all pages ending in `-new`, excluding `index-new`) surfaced two systemic issues plus a tail of schema/accessibility/content gaps that survived the earlier rounds.

**Critical**
- `index.astro`: the client-side 50/50 A/B redirect to `/home-new` now skips known bot user agents, so search/AI crawlers never get randomly routed to a `noindex` page — this was making Google's indexing signal for `/` (the live homepage) non-deterministic across crawls.
- Consolidated duplicate `NonprofitOrganization` JSON-LD nodes sharing one `@id` (`contact-new`, `donate-new`, `donate-2-new`, `media-new`) into a single merged schema via a new `organizationSchemaExtra` prop on `HomeLayout`, instead of each page emitting a second colliding node.

**High**
- Added `image` to Person schema for all 12 `team-new` members.
- `donate-new` now server-renders one donation variant by default (geo-based, non-randomized) so the donate CTA/form is present without JS; the client-side A/B script hides-all-then-shows-winner to avoid double-rendering.
- Added `width`/`height` to prevent CLS on images in `about-new`, `incubator-new`, `e4p-new` founder avatars, and `membership-new` hero.
- Fixed heading hierarchy skips (h1→h3, no h2) on `ideas-new`, `projects-new`, `tools-new`.
- `media-new`: switched misapplied `NewsArticle` schema to `mentions`/`CreativeWork`, since those articles live on third-party domains and lack the required `author`.

**Medium/Low**
- Added `@id`/`url`/`publisher` entity links on `legal-new`, `terms-new`, `privacy-policy-new`, `get-involved-new` WebPage schemas.
- Fixed `ItemList` schema on `projects-new`/`tools-new`: added `numberOfItems`, nested entries under proper `item` objects.
- Added `aria-hidden="true"` to decorative SVGs on `contact-new` and `get-involved-new`.
- Added reciprocal `terms-new` → `legal-new` link.
- Lengthened thin titles/descriptions on `donate-new`, `get-involved-new`, `mentorship-new`, `membership-new`, `media-new`, `terms-new`.
- Page-specific OG images for `team-new` and `media-new` (using existing on-page assets).
- Fixed `ideas-new` ItemList descriptions truncating mid-word.

**Deliberately not changed** (flagged rather than papered over):
- `mentorship-new`/`volunteer-new` OG images — neither page has a real image asset to reference; a mismatched placeholder would be worse than the current generic fallback.
- `dateModified` on `legal-new`/`terms-new`/`privacy-policy-new` (2025-08-05) — left as-is; bumping it without an actual legal review would fake a freshness signal.
- `tools-new` reused placeholder logo for 5 tools — no real logos available in the repo for those tools.

## Test plan
- [x] `pnpm check` — 0 errors
- [x] `pnpm build` — clean production build
- [x] `pnpm format:check` — no new issues (pre-existing unrelated warning on `volunteer.astro` only)
- [ ] Visual check of `/donate-new`, `/team-new`, `/media-new` in a browser (not yet done by me — these are unlinked `-new` draft pages, all still `noindex`)