### PR TITLE
fix(seo): address critical/high findings from -new pages SEO/GEO/AEO audit, part 4

### DIFF
--- a/src/pages/donate-2-new.astro
+++ b/src/pages/donate-2-new.astro
@@ -19,7 +19,7 @@ const membershipLive = getEnv("MEMBERSHIP_LIVE", Astro.locals) === "true";
       name: "Donate to Tech for Palestine",
       description:
         "Your donation helps us hire professionals, strengthen existing projects, and launch new initiatives for a free Palestine.",
-      target: "https://techforpalestine.org/donate-2-new",
+      target: "https://techforpalestine.org/donate",
     },
   }}
 >

--- a/src/pages/donate-new.astro
+++ b/src/pages/donate-new.astro
@@ -24,7 +24,7 @@ const defaultFormId = isUK ? "form-validaid-link" : "form-qgiv-link";
       name: "Donate to Tech for Palestine",
       description:
         "Your donation helps us strengthen existing projects and launch new initiatives for a free Palestine.",
-      target: "https://techforpalestine.org/donate-new",
+      target: "https://techforpalestine.org/donate",
     },
   }}
 >

--- a/src/pages/home-new.astro
+++ b/src/pages/home-new.astro
@@ -27,10 +27,12 @@ let openRoles: Array<{
 
 try {
   // This blocks SSR on every request (open-roles has averaged ~0.7-0.8s
-  // round-trip in production) — bound it so a slow/hanging upstream can't
-  // stall the page indefinitely.
+  // round-trip in production). The openings section is below the fold and
+  // already renders fine with zero roles, so cap the wait tightly rather
+  // than at 3s — a slow/hanging upstream should cost this page far less
+  // than that off its TTFB/LCP.
   const res = await fetch("https://hub.techforpalestine.org/api/public/open-roles", {
-    signal: AbortSignal.timeout(3000),
+    signal: AbortSignal.timeout(1200),
   });
   if (res.ok) {
     openRoles = await res.json();

--- a/src/pages/team-new.astro
+++ b/src/pages/team-new.astro
@@ -168,7 +168,7 @@ const peopleSchema = [...board, ...staff].map((member) => ({
                   />
                 </div>
                 <div class="border-t-2 border-brand px-5 pb-5 pt-4">
-                  <p class="ts-eyebrow mb-1 text-ink">{member.name}</p>
+                  <h3 class="ts-eyebrow mb-1 text-ink">{member.name}</h3>
                   <p class="ts-overline text-ink-secondary">{member.role}</p>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- `team-new.astro`: give staff members `h3` headings so markup matches the board-member pattern and the `Person` schema for each of them
- `donate-new.astro` / `donate-2-new.astro`: point `DonateAction.target` at the canonical `/donate` on both pages instead of self-referencing their own draft URLs, resolving a contradictory schema signal
- `home-new.astro`: cut the open-roles fetch timeout from 3s to 1.2s to reduce worst-case TTFB/LCP impact on this live A/B-tested page

Follow-up to the prior three -new pages SEO/GEO/AEO audit PRs (#505, #506, #507, #508). Scoped to only the Critical/High findings from a fresh full audit of all 24 `-new` draft pages; Medium/Low findings were left for a later pass.

## Test plan
- [x] `pnpm check` passes with 0 errors (only pre-existing hints unrelated to these files)
- [ ] Visually confirm staff grid on `/team-new` still renders as before (heading change is markup-only, no visual change expected)
- [ ] Confirm `/donate-new` and `/donate-2-new` still submit donations correctly
- [ ] Confirm `/home-new` open-roles section still populates under normal conditions