### PR TITLE
fix(home): update TechCrunch logo image URL in PressSection

### DIFF
--- a/src/components/home/PressSection.astro
+++ b/src/components/home/PressSection.astro
@@ -5,7 +5,7 @@ const logos = [
     alt: "The Guardian",
   },
   {
-    src: "https://e7.pngegg.com/pngimages/669/74/png-clipart-tc-techcrunch-logo-illustration-techcrunch-logo-icons-logos-emojis-iconic-brands.png",
+    src: "https://images.icon-icons.com/2699/PNG/512/techcrunch_logo_icon_170625.png",
     alt: "TechCrunch",
   },
   {


### PR DESCRIPTION
## Summary
- Updates the TechCrunch logo image used in the home-new PressSection to a new hosted URL.

## Test plan
- [ ] Visit `/` (home-new A/B variant) and confirm the TechCrunch logo in the press section renders correctly.