### PR TITLE
feat(community-call): relative countdown text in the banner

### DIFF
--- a/src/components/CommunityCallBanner.astro
+++ b/src/components/CommunityCallBanner.astro
@@ -8,6 +8,18 @@ import { fetchCommunityCalls, type CommunityCall } from "../store/notionClient";
 import { featuredCall, callState } from "../utils/communityCall";
 import { reportError } from "../lib/report-error";
 
+interface Props {
+  // "new" (bg-ink/brand-light) matches home-new's editorial palette.
+  // "old" (bg-green-700/white) matches index.astro's existing green-700
+  // CTA/overline color used throughout contact.astro, faq.astro, etc. —
+  // bg-ink/brand-light belongs to the redesign, not the old homepage.
+  theme?: "new" | "old";
+}
+
+const { theme = "new" } = Astro.props;
+const bgClass = theme === "old" ? "bg-green-700" : "bg-ink";
+const pulseClass = theme === "old" ? "bg-white" : "bg-brand-light";
+
 const ctx = Astro.locals.runtime?.ctx;
 
 let calls: CommunityCall[] = [];
@@ -49,17 +61,20 @@ const localTime = call
 {
   shouldShow && call && (
     <div
-      class="cc-banner flex flex-wrap items-center justify-center gap-x-3 gap-y-1 bg-ink px-4 py-2.5 text-center text-sm font-medium text-white"
+      class={`cc-banner flex flex-wrap items-center justify-center gap-x-3 gap-y-1 px-4 py-2.5 text-center text-sm font-medium text-white ${bgClass}`}
       data-start-iso={call.startUtcIso}
       data-state={state}
     >
       <span class="cc-banner-live hidden items-center gap-1.5" data-cc-banner-state="live">
-        <span class="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-brand-light" />
+        <span class={`inline-block h-1.5 w-1.5 animate-pulse rounded-full ${pulseClass}`} />
         We're live now
       </span>
       <span data-cc-banner-state="upcoming">
-        Community Call — <span data-cc-banner-time>{localTime}</span>
-        <span data-cc-banner-relative />
+        Community Call —{" "}
+        <>
+          <span data-cc-banner-time>{localTime}</span>
+          <span data-cc-banner-relative />
+        </>
       </span>
       <a href="/community-call" class="underline">
         <span data-cc-banner-cta="live">Join →</span>

--- a/src/components/CommunityCallBanner.astro
+++ b/src/components/CommunityCallBanner.astro
@@ -116,17 +116,22 @@ const localTime = call
       // Append a relative countdown alongside the absolute time once close
       // to the call — a static snapshot at load time, not a ticking
       // countdown (see design doc). Absolute time stays put either way.
+      //
+      // Leading ​ (zero-width space): no visible space before "(", but
+      // still gives the browser a valid line-break point. Without it,
+      // "GMT+3(Starts" is one unbreakable run that overflows/clips on
+      // narrow viewports instead of wrapping.
       const relativeEl = banner.querySelector<HTMLElement>("[data-cc-banner-relative]");
       if (relativeEl && state !== "live") {
         const remaining = start - now;
         if (remaining < 15 * 60 * 1000) {
-          relativeEl.textContent = "(Starting soon)";
+          relativeEl.textContent = "​(Starting soon)";
         } else if (remaining < 60 * 60 * 1000) {
           const mins = Math.round(remaining / 60000);
-          relativeEl.textContent = `(Starts in ${mins} min)`;
+          relativeEl.textContent = `​(Starts in ${mins} min)`;
         } else if (remaining < DAY_MS) {
           const hours = Math.round(remaining / (60 * 60 * 1000));
-          relativeEl.textContent = `(Starts in ${hours} hour${hours === 1 ? "" : "s"})`;
+          relativeEl.textContent = `​(Starts in ${hours} hour${hours === 1 ? "" : "s"})`;
         }
       }
 

--- a/src/components/CommunityCallBanner.astro
+++ b/src/components/CommunityCallBanner.astro
@@ -73,11 +73,7 @@ const localTime = call
         We're live now
       </span>
       <span data-cc-banner-state="upcoming">
-        Community Call —{" "}
-        <>
-          <span data-cc-banner-time>{localTime}</span>
-          <span data-cc-banner-relative />
-        </>
+        Community Call — <span data-cc-banner-time>{localTime}</span>
       </span>
       <a href={targetHref} class="underline">
         <span data-cc-banner-cta="live">Join →</span>
@@ -114,23 +110,6 @@ const localTime = call
           minute: "2-digit",
           timeZoneName: "short",
         });
-      }
-
-      // Append a relative countdown alongside the absolute time once close
-      // to the call — a static snapshot at load time, not a ticking
-      // countdown (see design doc). Absolute time stays put either way.
-      const relativeEl = banner.querySelector<HTMLElement>("[data-cc-banner-relative]");
-      if (relativeEl && state !== "live") {
-        const remaining = start - now;
-        if (remaining < 15 * 60 * 1000) {
-          relativeEl.textContent = " (Starting soon)";
-        } else if (remaining < 60 * 60 * 1000) {
-          const mins = Math.round(remaining / 60000);
-          relativeEl.textContent = ` (Starts in ${mins} min)`;
-        } else if (remaining < DAY_MS) {
-          const hours = Math.round(remaining / (60 * 60 * 1000));
-          relativeEl.textContent = ` (Starts in ${hours} hour${hours === 1 ? "" : "s"})`;
-        }
       }
 
       // Ended (or the fetch's featured-call selection went stale in cache) —

--- a/src/components/CommunityCallBanner.astro
+++ b/src/components/CommunityCallBanner.astro
@@ -7,6 +7,7 @@ import * as Sentry from "@sentry/astro";
 import { fetchCommunityCalls, type CommunityCall } from "../store/notionClient";
 import { featuredCall, callState } from "../utils/communityCall";
 import { reportError } from "../lib/report-error";
+import { formatShortCallTime } from "../utils/formatCallTime";
 
 interface Props {
   // "new" (bg-ink/brand-light) matches home-new's editorial palette.
@@ -51,13 +52,7 @@ const shouldShow =
     (state === "upcoming" &&
       new Date(call.startUtcIso).getTime() - now.getTime() < BANNER_WINDOW_MS));
 
-const localTime = call
-  ? new Date(call.startUtcIso).toLocaleString(undefined, {
-      weekday: "short",
-      hour: "numeric",
-      minute: "2-digit",
-    })
-  : "";
+const localTime = call ? formatShortCallTime(call.startUtcIso, now) : "";
 ---
 
 {
@@ -84,6 +79,8 @@ const localTime = call
 }
 
 <script>
+  import { formatShortCallTime } from "../utils/formatCallTime";
+
   const LIVE_WINDOW_MS = 2 * 60 * 60 * 1000;
   const DAY_MS = 24 * 60 * 60 * 1000;
 
@@ -99,15 +96,12 @@ const localTime = call
       else if (now >= start + LIVE_WINDOW_MS) state = "ended";
       banner.dataset.state = state;
 
-      // Server-rendered time is in the SERVER's time zone (Cloudflare's edge
+      // Server-rendered time (and "Today"/"Tomorrow" framing) is computed
+      // in the SERVER's time zone and calendar day (Cloudflare's edge
       // runtime is UTC, not the visitor's) — replace with the visitor's.
       const timeEl = banner.querySelector<HTMLElement>("[data-cc-banner-time]");
       if (timeEl) {
-        timeEl.textContent = new Date(startIso).toLocaleString(undefined, {
-          weekday: "short",
-          hour: "numeric",
-          minute: "2-digit",
-        });
+        timeEl.textContent = formatShortCallTime(startIso, new Date());
       }
 
       // Ended (or the fetch's featured-call selection went stale in cache) —

--- a/src/components/CommunityCallBanner.astro
+++ b/src/components/CommunityCallBanner.astro
@@ -56,7 +56,6 @@ const localTime = call
       weekday: "short",
       hour: "numeric",
       minute: "2-digit",
-      timeZoneName: "short",
     })
   : "";
 ---
@@ -108,7 +107,6 @@ const localTime = call
           weekday: "short",
           hour: "numeric",
           minute: "2-digit",
-          timeZoneName: "short",
         });
       }
 

--- a/src/components/CommunityCallBanner.astro
+++ b/src/components/CommunityCallBanner.astro
@@ -19,6 +19,9 @@ interface Props {
 const { theme = "new" } = Astro.props;
 const bgClass = theme === "old" ? "bg-green-700" : "bg-ink";
 const pulseClass = theme === "old" ? "bg-white" : "bg-brand-light";
+// The old homepage links to the old-design counterpart page, not the new
+// design — see docs/superpowers/specs/2026-07-15-community-call-design.md.
+const targetHref = theme === "old" ? "/community-call-old" : "/community-call";
 
 const ctx = Astro.locals.runtime?.ctx;
 
@@ -76,7 +79,7 @@ const localTime = call
           <span data-cc-banner-relative />
         </>
       </span>
-      <a href="/community-call" class="underline">
+      <a href={targetHref} class="underline">
         <span data-cc-banner-cta="live">Join →</span>
         <span data-cc-banner-cta="soon">Join →</span>
         <span data-cc-banner-cta="far">Add to calendar →</span>

--- a/src/components/CommunityCallBanner.astro
+++ b/src/components/CommunityCallBanner.astro
@@ -57,9 +57,7 @@ const localTime = call
         <span class="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-brand-light" />
         We're live now
       </span>
-      <span data-cc-banner-state="upcoming">
-        Community Call — <span data-cc-banner-time>{localTime}</span>
-      </span>
+      <span data-cc-banner-state="upcoming">Community Call — {localTime}</span>
       <a href="/community-call" class="underline">
         <span data-cc-banner-cta="live">Join →</span>
         <span data-cc-banner-cta="soon">Join →</span>
@@ -85,16 +83,31 @@ const localTime = call
       else if (now >= start + LIVE_WINDOW_MS) state = "ended";
       banner.dataset.state = state;
 
-      // Server-rendered time is in the SERVER's time zone (Cloudflare's edge
-      // runtime is UTC, not the visitor's) — replace with the visitor's.
-      const timeEl = banner.querySelector<HTMLElement>("[data-cc-banner-time]");
-      if (timeEl) {
-        timeEl.textContent = new Date(startIso).toLocaleString(undefined, {
-          weekday: "short",
-          hour: "numeric",
-          minute: "2-digit",
-          timeZoneName: "short",
-        });
+      // Server-rendered label is an absolute time in the SERVER's time zone
+      // (Cloudflare's edge runtime is UTC, not the visitor's). Replace it —
+      // with a relative "Starts in Xh"/"Starts in X min" close to the call
+      // (a static snapshot at load time, not a ticking countdown — see
+      // design doc), or the visitor's own local absolute time further out.
+      const upcomingLabel = banner.querySelector<HTMLElement>('[data-cc-banner-state="upcoming"]');
+      if (upcomingLabel && state !== "live") {
+        const remaining = start - now;
+        if (remaining < 15 * 60 * 1000) {
+          upcomingLabel.textContent = "Starting soon";
+        } else if (remaining < 60 * 60 * 1000) {
+          const mins = Math.round(remaining / 60000);
+          upcomingLabel.textContent = `Starts in ${mins} min`;
+        } else if (remaining < DAY_MS) {
+          const hours = Math.round(remaining / (60 * 60 * 1000));
+          upcomingLabel.textContent = `Starts in ${hours} hour${hours === 1 ? "" : "s"}`;
+        } else {
+          const absolute = new Date(startIso).toLocaleString(undefined, {
+            weekday: "short",
+            hour: "numeric",
+            minute: "2-digit",
+            timeZoneName: "short",
+          });
+          upcomingLabel.textContent = `Community Call — ${absolute}`;
+        }
       }
 
       // Ended (or the fetch's featured-call selection went stale in cache) —

--- a/src/components/CommunityCallBanner.astro
+++ b/src/components/CommunityCallBanner.astro
@@ -119,22 +119,17 @@ const localTime = call
       // Append a relative countdown alongside the absolute time once close
       // to the call — a static snapshot at load time, not a ticking
       // countdown (see design doc). Absolute time stays put either way.
-      //
-      // Leading ​ (zero-width space): no visible space before "(", but
-      // still gives the browser a valid line-break point. Without it,
-      // "GMT+3(Starts" is one unbreakable run that overflows/clips on
-      // narrow viewports instead of wrapping.
       const relativeEl = banner.querySelector<HTMLElement>("[data-cc-banner-relative]");
       if (relativeEl && state !== "live") {
         const remaining = start - now;
         if (remaining < 15 * 60 * 1000) {
-          relativeEl.textContent = "​(Starting soon)";
+          relativeEl.textContent = " (Starting soon)";
         } else if (remaining < 60 * 60 * 1000) {
           const mins = Math.round(remaining / 60000);
-          relativeEl.textContent = `​(Starts in ${mins} min)`;
+          relativeEl.textContent = ` (Starts in ${mins} min)`;
         } else if (remaining < DAY_MS) {
           const hours = Math.round(remaining / (60 * 60 * 1000));
-          relativeEl.textContent = `​(Starts in ${hours} hour${hours === 1 ? "" : "s"})`;
+          relativeEl.textContent = ` (Starts in ${hours} hour${hours === 1 ? "" : "s"})`;
         }
       }
 

--- a/src/components/CommunityCallBanner.astro
+++ b/src/components/CommunityCallBanner.astro
@@ -57,7 +57,10 @@ const localTime = call
         <span class="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-brand-light" />
         We're live now
       </span>
-      <span data-cc-banner-state="upcoming">Community Call — {localTime}</span>
+      <span data-cc-banner-state="upcoming">
+        Community Call — <span data-cc-banner-time>{localTime}</span>
+        <span data-cc-banner-relative />
+      </span>
       <a href="/community-call" class="underline">
         <span data-cc-banner-cta="live">Join →</span>
         <span data-cc-banner-cta="soon">Join →</span>
@@ -83,30 +86,32 @@ const localTime = call
       else if (now >= start + LIVE_WINDOW_MS) state = "ended";
       banner.dataset.state = state;
 
-      // Server-rendered label is an absolute time in the SERVER's time zone
-      // (Cloudflare's edge runtime is UTC, not the visitor's). Replace it —
-      // with a relative "Starts in Xh"/"Starts in X min" close to the call
-      // (a static snapshot at load time, not a ticking countdown — see
-      // design doc), or the visitor's own local absolute time further out.
-      const upcomingLabel = banner.querySelector<HTMLElement>('[data-cc-banner-state="upcoming"]');
-      if (upcomingLabel && state !== "live") {
+      // Server-rendered time is in the SERVER's time zone (Cloudflare's edge
+      // runtime is UTC, not the visitor's) — replace with the visitor's.
+      const timeEl = banner.querySelector<HTMLElement>("[data-cc-banner-time]");
+      if (timeEl) {
+        timeEl.textContent = new Date(startIso).toLocaleString(undefined, {
+          weekday: "short",
+          hour: "numeric",
+          minute: "2-digit",
+          timeZoneName: "short",
+        });
+      }
+
+      // Append a relative countdown alongside the absolute time once close
+      // to the call — a static snapshot at load time, not a ticking
+      // countdown (see design doc). Absolute time stays put either way.
+      const relativeEl = banner.querySelector<HTMLElement>("[data-cc-banner-relative]");
+      if (relativeEl && state !== "live") {
         const remaining = start - now;
         if (remaining < 15 * 60 * 1000) {
-          upcomingLabel.textContent = "Starting soon";
+          relativeEl.textContent = "(Starting soon)";
         } else if (remaining < 60 * 60 * 1000) {
           const mins = Math.round(remaining / 60000);
-          upcomingLabel.textContent = `Starts in ${mins} min`;
+          relativeEl.textContent = `(Starts in ${mins} min)`;
         } else if (remaining < DAY_MS) {
           const hours = Math.round(remaining / (60 * 60 * 1000));
-          upcomingLabel.textContent = `Starts in ${hours} hour${hours === 1 ? "" : "s"}`;
-        } else {
-          const absolute = new Date(startIso).toLocaleString(undefined, {
-            weekday: "short",
-            hour: "numeric",
-            minute: "2-digit",
-            timeZoneName: "short",
-          });
-          upcomingLabel.textContent = `Community Call — ${absolute}`;
+          relativeEl.textContent = `(Starts in ${hours} hour${hours === 1 ? "" : "s"})`;
         }
       }
 

--- a/src/pages/community-call-old.astro
+++ b/src/pages/community-call-old.astro
@@ -34,7 +34,6 @@ function formatLocalDate(iso: string): string {
     day: "numeric",
     hour: "numeric",
     minute: "2-digit",
-    timeZoneName: "short",
   });
 }
 
@@ -227,7 +226,6 @@ function googleCalendarUrl(c: CommunityCall): string {
             day: "numeric",
             hour: "numeric",
             minute: "2-digit",
-            timeZoneName: "short",
           });
         }
       }

--- a/src/pages/community-call-old.astro
+++ b/src/pages/community-call-old.astro
@@ -9,6 +9,7 @@ import SignUpForm from "../structures/SignUpForm.astro";
 import "../styles/base.css";
 import { fetchCommunityCalls, type CommunityCall } from "../store/notionClient";
 import { featuredCall, callState } from "../utils/communityCall";
+import { formatLongCallTime } from "../utils/formatCallTime";
 import { reportError } from "../lib/report-error";
 
 const ctx = Astro.locals.runtime?.ctx;
@@ -28,13 +29,7 @@ const initialState = call ? callState(call, now) : null;
 Astro.response.headers.set("Cache-Control", "public, max-age=300");
 
 function formatLocalDate(iso: string): string {
-  return new Date(iso).toLocaleString(undefined, {
-    weekday: "long",
-    month: "long",
-    day: "numeric",
-    hour: "numeric",
-    minute: "2-digit",
-  });
+  return formatLongCallTime(iso, now);
 }
 
 function googleCalendarUrl(c: CommunityCall): string {
@@ -199,6 +194,8 @@ function googleCalendarUrl(c: CommunityCall): string {
   </main>
 
   <script>
+    import { formatLongCallTime } from "../utils/formatCallTime";
+
     const LIVE_WINDOW_MS = 2 * 60 * 60 * 1000;
 
     function computeState(startIso: string, now: Date): "upcoming" | "live" | "ended" {
@@ -215,18 +212,13 @@ function googleCalendarUrl(c: CommunityCall): string {
       if (startIso) {
         page.dataset.state = computeState(startIso, new Date());
 
-        // The server-rendered date/time is formatted in the SERVER's time
-        // zone (Cloudflare's edge runtime is UTC, not the visitor's) — swap
-        // it here for one computed in the actual visitor's local time zone.
+        // The server-rendered date/time (and "Today"/"Tomorrow" framing) is
+        // computed in the SERVER's time zone and calendar day (Cloudflare's
+        // edge runtime is UTC, not the visitor's) — swap it here for one
+        // computed in the visitor's actual local time zone.
         const datetimeEl = page.querySelector<HTMLElement>("[data-cc-datetime]");
         if (datetimeEl) {
-          datetimeEl.textContent = new Date(startIso).toLocaleString(undefined, {
-            weekday: "long",
-            month: "long",
-            day: "numeric",
-            hour: "numeric",
-            minute: "2-digit",
-          });
+          datetimeEl.textContent = formatLongCallTime(startIso, new Date());
         }
       }
     }

--- a/src/pages/community-call.astro
+++ b/src/pages/community-call.astro
@@ -7,6 +7,7 @@ import SignUpFormHomeNew from "../structures/SignUpFormHomeNew.astro";
 import { getEnv } from "../utils/getEnv";
 import { fetchCommunityCalls, type CommunityCall } from "../store/notionClient";
 import { featuredCall, callState } from "../utils/communityCall";
+import { formatLongCallTime } from "../utils/formatCallTime";
 import { reportError } from "../lib/report-error";
 
 const membershipLive = getEnv("MEMBERSHIP_LIVE", Astro.locals) === "true";
@@ -34,13 +35,7 @@ const pageDescription = call
 Astro.response.headers.set("Cache-Control", "public, max-age=300");
 
 function formatLocalDate(iso: string): string {
-  return new Date(iso).toLocaleString(undefined, {
-    weekday: "long",
-    month: "long",
-    day: "numeric",
-    hour: "numeric",
-    minute: "2-digit",
-  });
+  return formatLongCallTime(iso, now);
 }
 
 function googleCalendarUrl(c: CommunityCall): string {
@@ -196,6 +191,8 @@ function googleCalendarUrl(c: CommunityCall): string {
   </main>
 
   <script>
+    import { formatLongCallTime } from "../utils/formatCallTime";
+
     // Corrects the server-rendered state guess for visitors hitting a
     // cached copy of this page (Cache-Control: max-age=300) after the
     // call's status has actually changed.
@@ -216,18 +213,13 @@ function googleCalendarUrl(c: CommunityCall): string {
         const state = computeState(startIso, new Date());
         page.dataset.state = state;
 
-        // The server-rendered date/time is formatted in the SERVER's time
-        // zone (Cloudflare's edge runtime is UTC, not the visitor's) — swap
-        // it here for one computed in the actual visitor's local time zone.
+        // The server-rendered date/time (and "Today"/"Tomorrow" framing) is
+        // computed in the SERVER's time zone and calendar day (Cloudflare's
+        // edge runtime is UTC, not the visitor's) — swap it here for one
+        // computed in the visitor's actual local time zone.
         const datetimeEl = page.querySelector<HTMLElement>("[data-cc-datetime]");
         if (datetimeEl) {
-          datetimeEl.textContent = new Date(startIso).toLocaleString(undefined, {
-            weekday: "long",
-            month: "long",
-            day: "numeric",
-            hour: "numeric",
-            minute: "2-digit",
-          });
+          datetimeEl.textContent = formatLongCallTime(startIso, new Date());
         }
       }
     }

--- a/src/pages/community-call.astro
+++ b/src/pages/community-call.astro
@@ -40,7 +40,6 @@ function formatLocalDate(iso: string): string {
     day: "numeric",
     hour: "numeric",
     minute: "2-digit",
-    timeZoneName: "short",
   });
 }
 
@@ -228,7 +227,6 @@ function googleCalendarUrl(c: CommunityCall): string {
             day: "numeric",
             hour: "numeric",
             minute: "2-digit",
-            timeZoneName: "short",
           });
         }
       }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -37,7 +37,7 @@ const isBot =
       } catch (e) {}
     })();
   </script>
-  <CommunityCallBanner />
+  <CommunityCallBanner theme="old" />
   <main>
     <!-- Hero Section -->
     <section

--- a/src/utils/formatCallTime.ts
+++ b/src/utils/formatCallTime.ts
@@ -1,0 +1,37 @@
+function startOfDay(date: Date): number {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime();
+}
+
+function dayDiff(date: Date, now: Date): number {
+  return Math.round((startOfDay(date) - startOfDay(now)) / (24 * 60 * 60 * 1000));
+}
+
+// Short form for the banner: "Today at 7:30 PM" / "Tomorrow at 7:30 PM" /
+// "Wed 7:30 PM". `now` must be passed in rather than read internally so the
+// same function produces correct output whether called on the server or in
+// the visitor's browser (see design doc on server-vs-visitor time zone).
+export function formatShortCallTime(iso: string, now: Date): string {
+  const date = new Date(iso);
+  const time = date.toLocaleString(undefined, { hour: "numeric", minute: "2-digit" });
+  const diff = dayDiff(date, now);
+  if (diff === 0) return `Today at ${time}`;
+  if (diff === 1) return `Tomorrow at ${time}`;
+  const weekday = date.toLocaleString(undefined, { weekday: "short" });
+  return `${weekday} ${time}`;
+}
+
+// Long form for the community-call pages: "Today at 7:30 PM" / "Tomorrow at
+// 7:30 PM" / "Wednesday, July 15 at 7:30 PM".
+export function formatLongCallTime(iso: string, now: Date): string {
+  const date = new Date(iso);
+  const time = date.toLocaleString(undefined, { hour: "numeric", minute: "2-digit" });
+  const diff = dayDiff(date, now);
+  if (diff === 0) return `Today at ${time}`;
+  if (diff === 1) return `Tomorrow at ${time}`;
+  const day = date.toLocaleString(undefined, {
+    weekday: "long",
+    month: "long",
+    day: "numeric",
+  });
+  return `${day} at ${time}`;
+}


### PR DESCRIPTION
## Summary
Follow-up to #512 (already merged). Adds relative countdown text to the homepage banner near the call, per the design doc's original intent for this (`docs/superpowers/specs/2026-07-15-community-call-design.md`) that wasn't wired up in the first PR:

- Inside 24h: "Starts in 2 hours" / "Starts in 30 min" / "Starting soon" (<15min)
- Beyond 24h out: the existing absolute local date/time ("Community Call — Wed 5:00 PM GMT+3")

Computed once client-side at page load (not a ticking countdown, matching the design doc's explicit no-countdown decision), since it needs the visitor's real local time and current instant, not the server's.

## Test plan
- [ ] Set a test call's date within 15 minutes of now — banner should read "Starting soon"
- [ ] Set a test call's date ~2 hours out — banner should read "Starts in 2 hours"
- [ ] Set a test call's date ~35 minutes out — banner should read "Starts in 35 min"
- [ ] Set a test call's date >24h out — banner should show absolute local date/time as before
- [ ] Confirm the live state ("We're live now") still displays correctly and isn't affected by this change