### PR TITLE
fix(team): correct spelling of Azza Hararah's name

### DIFF
--- a/src/pages/team-new.astro
+++ b/src/pages/team-new.astro
@@ -32,7 +32,7 @@ const staff = [
     posClass: "[object-position:center_15%]",
   },
   {
-    name: "Azza Harara",
+    name: "Azza Hararah",
     role: "Director of Volunteering and Recruitment",
     image: "/images/staff/azza.webp",
   },


### PR DESCRIPTION
## Summary
- Fixes a spelling typo on the team-new page: "Azza Harara" → "Azza Hararah"

## Test plan
- [x] Visually confirm the name renders correctly on `/team-new`