### PR TITLE
fix(mentorship): hide Be a Mentor nav/footer links during redesign

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -80,6 +80,7 @@ export default defineConfig({
           "/volunteer-new/",
           "/e4p-new/",
           "/help/hire-new/",
+          "/mentorship/",
           "/mentorship-new/",
           "/london-gathering-new/",
           "/get-involved-new/",

--- a/public/_redirects
+++ b/public/_redirects
@@ -6,7 +6,11 @@
 /project/* /projects 301
 /project-apply /projects 301
 /project-details/* /projects 301
-/mentor-application /mentorship 301
+/mentor-application / 301
+/mentorship / 301
+/mentorship/ / 301
+/mentorship-new / 301
+/mentorship-new/ / 301
 /admin/dropped-conversions /admin/conversions 301
 /index-new / 301
 /index-new/ / 301

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -30,7 +30,6 @@ const footerNavigation: Record<string, { href?: string; links: [string, string][
       ["Join our Discord", "https://techforpalestine.org/discord-invite"],
       ["E4P", "/e4p"],
       // ["Investors for Palestine", "/coming-soon"],
-      ["Be a Mentor", "/mentorship"],
       ["Volunteer", "/volunteer"],
       ["Join the Incubator", "https://techforpalestine.org/project-application-form"],
       ["Hire Palestinians", "/help/hire"],

--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -48,7 +48,6 @@ const navigation: Map<string, { href: string; submenu: [string, string][] | null
         ["Join the Incubator", "https://techforpalestine.org/project-application-form"],
         ["Volunteer", "/volunteer"],
         ["Entrepreneurs for Palestine", "/e4p"],
-        ["Be a Mentor", "/mentorship"],
         ["Hire Palestinians", "/help/hire"],
         ["Join our Discord", "https://techforpalestine.org/discord-invite"],
       ] as [string, string][],

--- a/src/components/home/FooterSection.astro
+++ b/src/components/home/FooterSection.astro
@@ -26,7 +26,6 @@ const navigation: Record<string, [string, string][]> = {
     ["Join the Incubator", "https://techforpalestine.org/project-application-form"],
     ["Volunteer", "/volunteer-new"],
     ["Entrepreneurs for Palestine", "/e4p-new"],
-    ["Be a Mentor", "/mentorship-new"],
     ["Hire Palestinians", "/help/hire-new"],
   ],
   Events: [

--- a/src/components/home/HomeNavbar.astro
+++ b/src/components/home/HomeNavbar.astro
@@ -43,7 +43,6 @@ const navItems = [
       },
       { label: "Volunteer", href: "/volunteer-new" },
       { label: "Entrepreneurs for Palestine", href: "/e4p-new" },
-      { label: "Be a Mentor", href: "/mentorship-new" },
       { label: "Hire Palestinians", href: "/help/hire-new" },
       { label: "Join our Discord", href: "https://techforpalestine.org/discord-invite" },
     ],


### PR DESCRIPTION
## Summary
- Removes the "Be a Mentor" link from both nav/footer variants (old `Navigation.astro`/`Footer.astro` and new `HomeNavbar.astro`/`FooterSection.astro`) while the mentorship program is redesigned.
- Adds `/mentorship/` to the sitemap exclude list in `astro.config.mjs`, matching the already-excluded `/mentorship-new/`.
- Adds 301 redirects for `/mentorship` and `/mentorship-new` to `/` in `public/_redirects`, blocking direct access to both pages during the redesign. Also repoints `/mentor-application` straight to `/` to avoid chaining through `/mentorship`.

## Test plan
- [ ] `pnpm build` succeeds
- [ ] Confirm "Be a Mentor" no longer appears in the "Get Involved" menu on both old-nav and new-nav (home) pages
- [ ] Confirm `/mentorship`, `/mentorship-new`, and `/mentor-application` all redirect to `/`