### PR TITLE
fix(team): remove Alaa Odeh's card from team pages

### DIFF
--- a/src/pages/team-new.astro
+++ b/src/pages/team-new.astro
@@ -26,12 +26,6 @@ const board = [
 const staff = [
   { name: "Afzal Mangal", role: "Director of Marketing", image: "/images/staff/afzal.webp" },
   {
-    name: "Alaa' Odeh",
-    role: "Director of Operations (Interim)",
-    image: "/images/staff/alaa.webp",
-    posClass: "[object-position:center_15%]",
-  },
-  {
     name: "Azza Hararah",
     role: "Director of Volunteering and Recruitment",
     image: "/images/staff/azza.webp",

--- a/src/pages/team.astro
+++ b/src/pages/team.astro
@@ -116,21 +116,6 @@ import "../styles/base.css";
                 </div>
               </div>
 
-              <!-- Alaa' Odeh -->
-              <div class="overflow-hidden rounded-lg bg-white shadow-md">
-                <div class="flex aspect-square items-center justify-center bg-gray-200">
-                  <img
-                    src="/images/staff/alaa.webp"
-                    alt="Alaa' Odeh"
-                    class="h-full w-full object-cover [object-position:center_20%]"
-                  />
-                </div>
-                <div class="p-6">
-                  <h3 class="mb-2 text-xl font-bold text-gray-900">Alaa' Odeh</h3>
-                  <p class="font-medium text-green-700">Director of Operations (Interim)</p>
-                </div>
-              </div>
-
               <!-- Azza Harara -->
               <div class="overflow-hidden rounded-lg bg-white shadow-md">
                 <div class="flex aspect-square items-center justify-center bg-gray-200">


### PR DESCRIPTION
## Summary
- Removes Alaa Odeh's picture and card from both `team.astro` and `team-new.astro`

## Test plan
- [ ] Visually confirm `/team` no longer shows Alaa's card
- [ ] Visually confirm `/team-new` no longer shows Alaa's card and grid layout still looks correct