### PR TITLE
fix(home-new): show nav bar immediately instead of after scroll

### DIFF
--- a/src/pages/home-new.astro
+++ b/src/pages/home-new.astro
@@ -77,7 +77,7 @@ const openRolesSchema = openRoles.length > 0 && {
     slot="head"
   />
   <CommunityCallBanner />
-  <HomeNavbar membershipLive={membershipLive} />
+  <HomeNavbar membershipLive={membershipLive} alwaysVisible />
   <main>
     <HeroSection membershipLive={membershipLive} />
     <ManifestoSection />


### PR DESCRIPTION
## Summary
- `home-new.astro` was the only `-new` redesign page not passing `alwaysVisible` to `HomeNavbar`, so its nav stayed hidden (`opacity: 0`, translated off-screen) until the user scrolled past half the viewport height.
- Every other `-new` page (about-new, donate-new, team-new, events-new, faq-new, etc.) already passes `alwaysVisible`, so this brings `home-new` in line with the rest.

## Test plan
- [ ] Visit `/home-new` and confirm the nav bar is visible immediately on page load, without scrolling
- [ ] Confirm nav bar still behaves correctly on scroll (no layout shift/flicker)
- [ ] Spot check another `-new` page (e.g. `/about-new`) to confirm nav behavior is unchanged there