### PR TITLE
fix(donate-new): give ValidAid iframe a default height

### DIFF
--- a/src/pages/donate-new.astro
+++ b/src/pages/donate-new.astro
@@ -103,7 +103,7 @@ const defaultFormId = isUK ? "form-validaid-link" : "form-qgiv-link";
                     id="validaid-iframe-event-236"
                     src="https://validaid.org/embed/event/236"
                     title="Tech for Palestine"
-                    class="w-full border-0"
+                    class="validaid-iframe w-full border-0"
                     allow="payment"></iframe>
                 </div>
               </div>
@@ -225,6 +225,10 @@ const defaultFormId = isUK ? "form-validaid-link" : "form-qgiv-link";
 <style>
   :global(iframe.qgiv-embed) {
     height: 800px !important;
+  }
+
+  .validaid-iframe {
+    height: 800px;
   }
 
   .donate-animate {


### PR DESCRIPTION
## Summary
- The ValidAid embed on `/donate-new?variant=validaid` had no default height and relied solely on a `postMessage` resize event, so it rendered at the browser default (~150px) until that message arrived — making the form too small to use.
- Give the iframe an 800px default height (matching the Qgiv embed), which the resize handler still overrides once ValidAid reports its actual content height.

## Test plan
- [ ] Visit `/donate-new?variant=validaid` and confirm the form is usable-sized on load, before/without the resize postMessage firing
- [ ] Confirm the iframe still resizes correctly once ValidAid's content loads and posts its height