### PR TITLE
fix(home-new): fix mobile hero stall, drop redundant logo/scroll cue

### DIFF
--- a/src/components/home/HeroSection.astro
+++ b/src/components/home/HeroSection.astro
@@ -20,35 +20,21 @@ const { membershipLive = false } = Astro.props;
       class="animate-ken-burns h-[calc(100svh-2rem)] min-h-[500px] w-full object-cover object-center motion-reduce:animate-none sm:h-[calc(100svh-3rem)]"
     />
 
-    <!-- Mobile overlay (below 810px): logo + scroll down -->
-    <div class="absolute inset-0 flex flex-col items-center gap-6 pt-16 min-[810px]:hidden">
-      <div class="hero-logo">
-        <img
-          src="/logos/logo-dark.webp"
-          alt="Tech for Palestine"
-          width="163"
-          height="48"
-          class="h-12 w-auto"
-        />
+    <!-- Mobile overlay (below 810px): headline + primary CTA, same hierarchy as desktop -->
+    <div class="absolute inset-0 flex flex-col justify-end p-4 min-[810px]:hidden">
+      <div class="hero-card rounded-3xl bg-[#ffffffa3] px-4 py-5">
+        <h1 class="ts-display hero-h1-a hero-mobile-fast mb-4 text-left text-ink">
+          Join the movement behind 90+ projects for Palestine
+        </h1>
+        <div class="hero-cta-b hero-mobile-fast">
+          <Button
+            href={membershipLive ? "/membership" : "/get-involved-new"}
+            variant="primary"
+            size="lg"
+            arrow>{membershipLive ? "Become a member" : "Get involved"}</Button
+          >
+        </div>
       </div>
-      <a
-        href="#mobile-content"
-        class="hero-cta-a ts-label flex flex-col items-center gap-2 rounded-sm text-brand focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand"
-      >
-        Scroll down
-        <svg
-          class="scroll-indicator"
-          width="20"
-          height="20"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="2"
-          aria-hidden="true"
-        >
-          <path d="M12 5v14M5 13l7 7 7-7"></path>
-        </svg>
-      </a>
     </div>
 
     <!-- Desktop overlay (810px+): full hero card -->
@@ -118,35 +104,22 @@ const { membershipLive = false } = Astro.props;
   </div>
 
   <!-- Mobile content below hero (below 810px) -->
-  <div id="mobile-content" class="pt-20 min-[810px]:hidden">
-    <h1 class="ts-display hero-h1-a mb-8 text-left text-ink">
-      Join the movement behind 90+ projects for Palestine
-    </h1>
-    <div class="flex flex-col items-start gap-4">
-      <div class="hero-cta-a">
-        <Button href="#portfolio" variant="ghost" class="!border-transparent hover:!bg-transparent">
-          See what we've built
-          <svg
-            width="18"
-            height="18"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2.5"
-            aria-hidden="true"
-          >
-            <path d="M12 5v14M5 13l7 7 7-7"></path>
-          </svg>
-        </Button>
-      </div>
-      <div class="hero-cta-b">
-        <Button
-          href={membershipLive ? "/membership" : "/get-involved-new"}
-          variant="primary"
-          size="lg"
-          arrow>{membershipLive ? "Become a member" : "Get involved"}</Button
+  <div id="mobile-content" class="pt-8 min-[810px]:hidden">
+    <div class="hero-cta-a">
+      <Button href="#portfolio" variant="ghost" class="!border-transparent hover:!bg-transparent">
+        See what we've built
+        <svg
+          width="18"
+          height="18"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2.5"
+          aria-hidden="true"
         >
-      </div>
+          <path d="M12 5v14M5 13l7 7 7-7"></path>
+        </svg>
+      </Button>
     </div>
   </div>
 </section>

--- a/src/components/home/HeroSection.astro
+++ b/src/components/home/HeroSection.astro
@@ -21,7 +21,7 @@ const { membershipLive = false } = Astro.props;
     />
 
     <!-- Mobile overlay (below 810px): headline + primary CTA, same hierarchy as desktop -->
-    <div class="absolute inset-0 flex flex-col justify-end p-4 min-[810px]:hidden">
+    <div class="absolute inset-0 flex flex-col justify-center p-4 min-[810px]:hidden">
       <div class="hero-card rounded-3xl bg-[#ffffffa3] px-4 py-5">
         <h1 class="ts-display hero-h1-a hero-mobile-fast mb-4 text-left text-ink">
           Join the movement behind 90+ projects for Palestine

--- a/src/pages/donate-new.astro
+++ b/src/pages/donate-new.astro
@@ -67,6 +67,7 @@ const defaultFormId = isUK ? "form-validaid-link" : "form-qgiv-link";
                   data-embed-id="83460"
                   data-embed="https://secure.qgiv.com/for/techforpalestine-websitedonationform/embed/83460/amount/1620629/recurring/"
                   data-width="630"
+                  data-lenis-prevent
                 >
                 </div>
               </div>
@@ -86,6 +87,7 @@ const defaultFormId = isUK ? "form-validaid-link" : "form-qgiv-link";
                   data-embed-id="83460"
                   data-embed="https://secure.qgiv.com/for/techforpalestine-websitedonationform/embed/83460/amount/1620629/recurring/"
                   data-width="630"
+                  data-lenis-prevent
                 >
                 </div>
               </div>
@@ -224,7 +226,7 @@ const defaultFormId = isUK ? "form-validaid-link" : "form-qgiv-link";
 
 <style>
   :global(iframe.qgiv-embed) {
-    height: 800px !important;
+    height: 800px;
   }
 
   .validaid-iframe {

--- a/src/styles/design-system.css
+++ b/src/styles/design-system.css
@@ -218,10 +218,6 @@ html.no-js .hero-logo {
   filter: none;
 }
 
-html.no-js .scroll-indicator {
-  animation: none;
-}
-
 @keyframes blurIn {
   from {
     opacity: 0;
@@ -272,6 +268,16 @@ html.no-js .scroll-indicator {
 }
 .hero-logo {
   animation: fadeUp 0.6s cubic-bezier(0.25, 1, 0.5, 1) 1.3s both;
+}
+
+/* Mobile hero card: headline + CTA sit directly on the image, no desktop-length delay */
+@media (max-width: 809px) {
+  .hero-h1-a.hero-mobile-fast {
+    animation-delay: 0.1s;
+  }
+  .hero-cta-b.hero-mobile-fast {
+    animation-delay: 0.3s;
+  }
 }
 
 @keyframes kenBurns {
@@ -370,22 +376,6 @@ html.no-js .scroll-indicator {
   animation-delay: 10.5s;
 }
 
-/* Scroll indicator bounce */
-@keyframes scrollBounce {
-  0%,
-  100% {
-    transform: translateY(0);
-    opacity: 1;
-  }
-  50% {
-    transform: translateY(6px);
-    opacity: 0.6;
-  }
-}
-.scroll-indicator {
-  animation: scrollBounce 1.8s ease-in-out infinite;
-}
-
 @media (prefers-reduced-motion: reduce) {
   /* Hero — show at final resting state immediately */
   .hero-card {
@@ -402,11 +392,6 @@ html.no-js .scroll-indicator {
     opacity: 1;
     transform: none;
     filter: none;
-  }
-
-  /* Scroll indicator — stop bouncing */
-  .scroll-indicator {
-    animation: none;
   }
 
   /* Ken-burns — disable on all images */


### PR DESCRIPTION
## Summary

**Mobile hero stall (`/home-new`)**
- The mobile hero overlay showed a logo and a bouncing "Scroll down" hint, both fading in on a fixed 1-1.3s CSS `animation-delay` decoupled from the hero image's actual load state — this read as a stall/dead-air even on a fast connection with the image already painted.
- The logo was a leftover from before the navbar was made `alwaysVisible` (#519) — it used to be the only branding shown pre-scroll; now the navbar shows the logo from the first frame, making the hero's copy redundant.
- Replaced both with the headline + primary CTA sitting directly on the hero image (mirroring desktop's `.hero-card` glass panel), with a short mobile-only animation delay (`.hero-mobile-fast`) instead of the desktop-length stagger. The secondary "See what we've built" link stays as the first thing below the fold.
- Removed the now-dead `scroll-indicator`/`scrollBounce` CSS (base rule, keyframes, `no-js` and `reduced-motion` overrides).

**Qgiv donation form clipped mid-flow (`/donate-new`)**
- `iframe.qgiv-embed` had a `height: 800px !important` rule, which permanently overrides Qgiv's own postMessage-driven resize (the same mechanism ValidAid uses, fixed correctly in #520 *without* `!important`). Once a visitor advances past whatever fits in 800px, the rest of the form becomes invisible and unreachable, with no scrollbar exposed.
- Plausible confirms the impact: `/donate-new` visitors average **3s** on page and **1** lifetime completed donation via that page, vs **148s** and **140+** on the old `/donate`.
- Also added the missing `data-lenis-prevent` on the Qgiv containers, matching the convention already used for the ValidAid iframe and every other embedded widget on Lenis-scrolled pages.

## Test plan
- [ ] Load `/home-new` on a mobile viewport (< 810px): confirm headline + primary CTA appear promptly on the hero image, no logo/scroll-down artifact, no dead-air pop-in
- [ ] Confirm desktop (≥ 810px) hero is unchanged
- [ ] Confirm `prefers-reduced-motion` still shows everything at rest immediately
- [ ] Confirm the "See what we've built" jump link below the fold still scrolls to `#portfolio`
- [ ] On `/donate-new`, step through the full Qgiv flow (amount → details → payment → confirmation) on both desktop and mobile and confirm nothing is clipped/unreachable once the iframe needs to grow past 800px
- [ ] Confirm the ValidAid (UK) variant on `/donate-new` still renders and resizes correctly