### PR TITLE
Remove Lenis smooth-scroll from -new pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "chart.js": "^4.5.1",
     "install": "^0.13.0",
     "leaflet": "^1.9.4",
-    "lenis": "^1.3.23",
     "marked": "^15.0.12",
     "moderndash": "^3.12.0",
     "react": "^19.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,9 +114,6 @@ importers:
       leaflet:
         specifier: ^1.9.4
         version: 1.9.4
-      lenis:
-        specifier: ^1.3.23
-        version: 1.3.23(react@19.2.0)
       marked:
         specifier: ^15.0.12
         version: 15.0.12
@@ -2812,20 +2809,6 @@ packages:
 
   leaflet@1.9.4:
     resolution: {integrity: sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==}
-
-  lenis@1.3.23:
-    resolution: {integrity: sha512-YxYq3TJqj9sJNv0V9SkyQHejt14xwyIwgDaaMK89Uf9SxQfIszu+gTQSSphh6BWlLTNVKvvXAGkg+Zf+oFIevg==}
-    peerDependencies:
-      '@nuxt/kit': '>=3.0.0'
-      react: '>=17.0.0'
-      vue: '>=3.0.0'
-    peerDependenciesMeta:
-      '@nuxt/kit':
-        optional: true
-      react:
-        optional: true
-      vue:
-        optional: true
 
   lilconfig@3.1.3:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
@@ -7088,10 +7071,6 @@ snapshots:
   kolorist@1.8.0: {}
 
   leaflet@1.9.4: {}
-
-  lenis@1.3.23(react@19.2.0):
-    optionalDependencies:
-      react: 19.2.0
 
   lilconfig@3.1.3: {}
 

--- a/src/components/IdeasWithTabsNew.tsx
+++ b/src/components/IdeasWithTabsNew.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef } from "react";
 import { flushSync } from "react-dom";
 import RichTextRenderer from "./RichTextRenderer.tsx";
+import { useBodyScrollLock } from "../utils/useBodyScrollLock";
 import type { RichTextSegment, NotionRichText } from "../types/richText";
 
 type Idea = {
@@ -58,18 +59,7 @@ export default function IdeasWithTabsNew({
     return () => document.removeEventListener("keydown", onKeyDown);
   }, [activeIdea]);
 
-  // Freeze Lenis (smooth scroll) while modal is open so wheel events can't move the page.
-  useEffect(() => {
-    const lenis = (window as any).__lenis;
-    if (activeIdea) {
-      lenis?.stop();
-    } else {
-      lenis?.start();
-    }
-    return () => {
-      lenis?.start();
-    };
-  }, [activeIdea]);
+  useBodyScrollLock(Boolean(activeIdea));
 
   const openIdea = (idea: Idea) => {
     if (closeTimer.current) clearTimeout(closeTimer.current);
@@ -182,7 +172,6 @@ export default function IdeasWithTabsNew({
         >
           <div
             ref={panelRef}
-            data-lenis-prevent
             className={[
               "relative max-h-[90vh] w-full max-w-2xl overflow-y-auto overscroll-y-contain rounded-[20px] border border-butter bg-page p-6 shadow-xl min-[810px]:p-8",
               "transition-all duration-300 ease-out motion-reduce:transition-none",

--- a/src/components/events/EventModal.tsx
+++ b/src/components/events/EventModal.tsx
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import { primaryEventLink } from "../../store/eventsClient";
 import { displayTitle } from "../../utils/eventSections";
 import { parseEventDescription, renderInlineText } from "../../utils/eventDescription";
+import { useBodyScrollLock } from "../../utils/useBodyScrollLock";
 import { ArrowRight, CloseIcon, parseDateParts, type SelectedEvent } from "./eventsShared";
 import { EventPreviewImage } from "./EventPreviewImage";
 
@@ -46,22 +47,16 @@ export function EventModal({ selected, onClose }: EventModalProps) {
   const { link: infoLink, label: infoLabel } = primaryEventLink(event, isPast);
   const title = displayTitle(event);
 
+  useBodyScrollLock(true);
+
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.key === "Escape") onClose();
     };
     document.addEventListener("keydown", onKeyDown);
 
-    // This site's pages scroll via Lenis (window.__lenis), which intercepts
-    // wheel/touch events itself — CSS `overflow: hidden` on html/body alone
-    // doesn't stop it. Stop Lenis while the modal is open, same pattern as
-    // ProjectDrawer.tsx.
-    const lenis = (window as any).__lenis;
-    lenis?.stop();
-
     return () => {
       document.removeEventListener("keydown", onKeyDown);
-      lenis?.start();
     };
   }, [onClose]);
 
@@ -78,7 +73,7 @@ export function EventModal({ selected, onClose }: EventModalProps) {
         aria-modal="true"
         aria-label={title}
       >
-        <div data-lenis-prevent className="overflow-y-auto overscroll-y-contain">
+        <div className="overflow-y-auto overscroll-y-contain">
           <div className="relative flex aspect-[16/9] items-center justify-center overflow-hidden bg-sand">
             <EventPreviewImage event={event} alt={title} className="h-full w-full object-contain" />
             <button

--- a/src/components/events/EventsNew.tsx
+++ b/src/components/events/EventsNew.tsx
@@ -53,9 +53,8 @@ export default function EventsNew({ initialEvents = [] }: EventsNewProps) {
 
   // Direct links to a category (e.g. /events-new#book-club) land here before
   // this island has rendered its sections, so the browser's native hash jump
-  // has nothing to scroll to yet. This page scrolls via Lenis (window.__lenis),
-  // which intercepts native scrolling, so once content is up we scroll to the
-  // hash target ourselves — same pattern as the modal's Lenis stop/start.
+  // has nothing to scroll to yet — scroll to the hash target ourselves once
+  // content is up.
   useEffect(() => {
     if (loading) return;
     const hash = window.location.hash.slice(1);
@@ -63,12 +62,7 @@ export default function EventsNew({ initialEvents = [] }: EventsNewProps) {
     const target = document.getElementById(hash);
     if (!target) return;
 
-    const lenis = (window as any).__lenis;
-    if (lenis?.scrollTo) {
-      lenis.scrollTo(target);
-    } else {
-      target.scrollIntoView({ block: "start" });
-    }
+    target.scrollIntoView({ block: "start" });
   }, [loading]);
 
   const sections = groupIntoSections(events);

--- a/src/components/home/WhySection.astro
+++ b/src/components/home/WhySection.astro
@@ -10,7 +10,7 @@
       <!-- Video -->
       <div class="why-video">
         <p class="ts-overline mb-4 text-ink-secondary">Paul & Greta on Palestine and media bias</p>
-        <div data-lenis-prevent class="relative aspect-video overflow-hidden rounded-2xl">
+        <div class="relative aspect-video overflow-hidden rounded-2xl">
           <iframe
             src="https://www.youtube-nocookie.com/embed/etNsXTm4mSc"
             title="Greta Thunberg | Tech for Palestine Brussels Conference 2026"

--- a/src/components/membership/MembershipDues.tsx
+++ b/src/components/membership/MembershipDues.tsx
@@ -16,7 +16,7 @@ function QgivEmbed() {
   }, []);
 
   return (
-    <div className="max-h-[640px] overflow-hidden" data-lenis-prevent>
+    <div className="max-h-[640px] overflow-hidden">
       <div
         className="qgiv-embed-container"
         data-qgiv-embed="true"

--- a/src/components/projects/ProjectDrawer.tsx
+++ b/src/components/projects/ProjectDrawer.tsx
@@ -9,6 +9,7 @@ import {
   formatDate,
 } from "./projectData";
 import { getActiveSocialFields, getSocialHref } from "./socialIcons";
+import { useBodyScrollLock } from "../../utils/useBodyScrollLock";
 
 interface ProjectDrawerProps {
   project: ProjectItem | null;
@@ -90,18 +91,7 @@ export default function ProjectDrawer({ project, open, onClose, triggerRef }: Pr
     }
   }, [open]);
 
-  // Freeze Lenis (smooth scroll) while modal is open so wheel events can't move the page.
-  useEffect(() => {
-    const lenis = (window as any).__lenis;
-    if (open) {
-      lenis?.stop();
-    } else {
-      lenis?.start();
-    }
-    return () => {
-      lenis?.start();
-    };
-  }, [open]);
+  useBodyScrollLock(open);
 
   // Focus management + ESC key
   useEffect(() => {
@@ -170,7 +160,6 @@ export default function ProjectDrawer({ project, open, onClose, triggerRef }: Pr
     >
       <div
         ref={panelRef}
-        data-lenis-prevent
         className={[
           "relative max-h-[90vh] w-full max-w-2xl overflow-y-auto overscroll-y-contain rounded-[20px] border border-butter bg-page p-6 shadow-xl min-[810px]:p-8",
           "transition-all duration-300 ease-out motion-reduce:transition-none",

--- a/src/layouts/HomeLayout.astro
+++ b/src/layouts/HomeLayout.astro
@@ -172,46 +172,6 @@ const organizationSchema = {
 
     <slot name="head" />
 
-    <script>
-      import Lenis from "lenis";
-
-      if (!window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
-        const lenis = new Lenis({
-          duration: 1.8,
-          easing: (t: number) => Math.min(1, 1.001 - Math.pow(2, -10 * t)),
-          smoothWheel: true,
-        });
-
-        document.querySelectorAll('a[href^="#"]').forEach((anchor) => {
-          anchor.addEventListener("click", (e) => {
-            const href = (anchor as HTMLAnchorElement).getAttribute("href");
-            if (!href) return;
-            const target = document.querySelector(href);
-            if (target) {
-              e.preventDefault();
-              lenis.scrollTo(target as HTMLElement);
-            }
-          });
-        });
-
-        (window as any).__lenis = lenis;
-
-        // Stop Lenis while the native scrollbar is being dragged
-        document.addEventListener("pointerdown", (e) => {
-          if (e.clientX >= document.documentElement.clientWidth) {
-            lenis.stop();
-            window.addEventListener("pointerup", () => lenis.start(), { once: true });
-          }
-        });
-
-        function raf(time: number) {
-          lenis.raf(time);
-          requestAnimationFrame(raf);
-        }
-        requestAnimationFrame(raf);
-      }
-    </script>
-
     <script defer src="https://pal-chat.net/pal-chat-lite/latest/ChatBox.js"></script>
     <script async src="https://plausible.io/js/pa-gMn1NrWB3uBANu6ua9M8N.js"></script>
     <script>

--- a/src/pages/donate-new.astro
+++ b/src/pages/donate-new.astro
@@ -67,7 +67,6 @@ const defaultFormId = isUK ? "form-validaid-link" : "form-qgiv-link";
                   data-embed-id="83460"
                   data-embed="https://secure.qgiv.com/for/techforpalestine-websitedonationform/embed/83460/amount/1620629/recurring/"
                   data-width="630"
-                  data-lenis-prevent
                 >
                 </div>
               </div>
@@ -87,7 +86,6 @@ const defaultFormId = isUK ? "form-validaid-link" : "form-qgiv-link";
                   data-embed-id="83460"
                   data-embed="https://secure.qgiv.com/for/techforpalestine-websitedonationform/embed/83460/amount/1620629/recurring/"
                   data-width="630"
-                  data-lenis-prevent
                 >
                 </div>
               </div>
@@ -100,7 +98,7 @@ const defaultFormId = isUK ? "form-validaid-link" : "form-qgiv-link";
                     class="text-brand underline hover:text-brand-hover">Click here to donate</a
                   >.
                 </p>
-                <div data-lenis-prevent>
+                <div>
                   <iframe
                     id="validaid-iframe-event-236"
                     src="https://validaid.org/embed/event/236"

--- a/src/pages/e4p-new.astro
+++ b/src/pages/e4p-new.astro
@@ -403,7 +403,7 @@ const peopleSchema = [...testimonials, ...founders].map((person) => ({
           <div class="grid grid-cols-1 gap-8 min-[810px]:grid-cols-2">
             <div>
               <p class="ts-label mb-4 text-ink">Americas</p>
-              <div class="overflow-hidden rounded-[20px] border border-butter" data-lenis-prevent>
+              <div class="overflow-hidden rounded-[20px] border border-butter">
                 <iframe
                   src="https://calendly.com/hsyed-hsyedlegal/entrepreneurs-for-palestine?background_color=ffffff&text_color=1a1a1a&primary_color=cf1026"
                   width="100%"
@@ -414,7 +414,7 @@ const peopleSchema = [...testimonials, ...founders].map((person) => ({
             </div>
             <div>
               <p class="ts-label mb-4 text-ink">Europe &amp; Asia</p>
-              <div class="overflow-hidden rounded-[20px] border border-butter" data-lenis-prevent>
+              <div class="overflow-hidden rounded-[20px] border border-butter">
                 <iframe
                   src="https://calendly.com/megan-techforpalestine/30min?background_color=ffffff&text_color=1a1a1a&primary_color=cf1026"
                   width="100%"

--- a/src/pages/media-new.astro
+++ b/src/pages/media-new.astro
@@ -519,7 +519,7 @@ const pressMentions = [leadArticle, ...articles].map((a) => ({
           {
             interviews.map((interview) => (
               <div class="media-animate">
-                <div data-lenis-prevent class="overflow-hidden rounded-[20px]">
+                <div class="overflow-hidden rounded-[20px]">
                   <iframe
                     src={`https://www.youtube-nocookie.com/embed/${interview.id}`}
                     title={interview.title}

--- a/src/structures/SignUpForm.astro
+++ b/src/structures/SignUpForm.astro
@@ -1,4 +1,4 @@
-<div class="flex justify-center" data-lenis-prevent>
+<div class="flex justify-center">
   <div class="w-full max-w-[560px] text-center">
     <script
       async

--- a/src/structures/SignUpFormHomeNew.astro
+++ b/src/structures/SignUpFormHomeNew.astro
@@ -1,4 +1,4 @@
-<div class="flex justify-center" data-lenis-prevent>
+<div class="flex justify-center">
   <div class="w-full max-w-[560px] text-center">
     <script
       async

--- a/src/utils/useBodyScrollLock.ts
+++ b/src/utils/useBodyScrollLock.ts
@@ -1,0 +1,14 @@
+import { useEffect } from "react";
+
+export function useBodyScrollLock(isLocked: boolean): void {
+  useEffect(() => {
+    if (!isLocked) return;
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [isLocked]);
+}


### PR DESCRIPTION
## Summary
- Removes the Lenis library entirely: the `HomeLayout.astro` init/raf loop/anchor-scroll wiring, the `window.__lenis` global, all `data-lenis-prevent` markup, and the `lenis` npm dependency. Scrolling and anchor links on all `-new` pages now behave natively.
- Adds a small shared `useBodyScrollLock` hook (`src/utils/useBodyScrollLock.ts`) and swaps it in for the Lenis `stop()/start()` calls that previously froze background scroll in `EventModal`, `IdeasWithTabsNew`'s idea modal, and `ProjectDrawer`.
- Simplifies `EventsNew.tsx`'s hash-deep-link scroll to a plain `scrollIntoView` (no Lenis branch needed).

## Test plan
- [ ] `pnpm dev`, visit `home-new` and confirm the page scrolls and feels normal (native, no smooth-scroll)
- [ ] `events-new`: click a category anchor link and deep-link directly to `/events-new#book-club` — confirm it jumps to the right section
- [ ] `ideas-new`: open/close an idea modal, confirm background scroll is locked while open and restored on close
- [ ] `projects-new`: open/close the project drawer, same scroll-lock check
- [ ] `donate-new`, `e4p-new`, `media-new`: confirm their internally-scrollable containers (qgiv embed, ValidAid iframe, FAQ/media panels) still scroll independently
- [ ] `pnpm check` passes (already verified locally, 0 errors)