### PR TITLE
fix(events): correct visitor timezone, polish legacy /events, richer previews

### DIFF
--- a/src/components/Events.tsx
+++ b/src/components/Events.tsx
@@ -1,23 +1,5 @@
 import { useContext, useEffect, useState } from "react";
-import {
-  Box,
-  Typography,
-  Card,
-  Button,
-  Link,
-  Fade,
-  IconButton,
-  Dialog,
-  DialogContent,
-  DialogActions,
-  Chip,
-} from "@mui/material";
-import EventBusyIcon from "@mui/icons-material/EventBusy";
-import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
-import ArrowForwardIcon from "@mui/icons-material/ArrowForward";
-import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
-import ChevronRightIcon from "@mui/icons-material/ChevronRight";
-import CloseIcon from "@mui/icons-material/Close";
+import { Dialog, DialogContent, DialogActions } from "@mui/material";
 import { hasMeaningfulDescription, primaryEventLink, type EventItem } from "../store/eventsClient";
 import {
   displayTitle,
@@ -27,25 +9,57 @@ import {
   type UpcomingEvent,
 } from "../utils/eventSections";
 import { copyAnchorLink } from "../utils/copyAnchorLink";
-import { parseEventDescription, renderInlineText } from "../utils/eventDescription";
+import {
+  formatSpeakerList,
+  getDescriptionExcerpt,
+  getEventSpeakers,
+  parseEventDescription,
+  renderInlineText,
+} from "../utils/eventDescription";
 import { EventPreviewImage } from "./events/EventPreviewImage";
 import {
+  ArrowRight,
+  ChevronDown,
+  CloseIcon,
   EventModalContext,
-  parseDateParts,
   useCarouselScroll,
-  weekdayAbbrev,
+  useEventDate,
   type SelectedEvent,
 } from "./events/eventsShared";
 
 const UPCOMING_WINDOW_DAYS = 60;
 const COPIED_FEEDBACK_MS = 1500;
 
+// Font sizes only (not family/weight/color) matched to /events-new's type
+// scale in src/styles/design-system.css, stepped at the same 390/810/1200
+// breakpoints. Each constant is named after the .ts-* role it mirrors.
+const TS_EDITORIAL_SIZE =
+  "text-[36px] leading-[1.18] min-[810px]:text-[42px] min-[1200px]:text-[48px]"; // section headings
+const TS_HEADING_SIZE =
+  "text-[32px] leading-[1.22] min-[810px]:text-[36px] min-[1200px]:text-[38px]"; // day-of-month numerals
+const TS_SUBHEADING_SIZE =
+  "text-[28px] leading-[1.22] min-[810px]:text-[30px] min-[1200px]:text-[32px]"; // event titles
+const TS_EYEBROW_SIZE =
+  "text-[18px] leading-[1.32] min-[810px]:text-[19px] min-[1200px]:text-[24px]"; // description sub-headings
+const TS_BODY_LARGE_SIZE = "text-[18px] leading-[1.48] min-[810px]:text-[20px]"; // empty-state message
+const TS_BODY_SIZE = "text-[16px] leading-[1.22] min-[810px]:text-[18px]"; // category subtitle, description paragraphs
+const TS_LABEL_SIZE = "text-[16px] leading-[1] min-[810px]:text-[18px]"; // button labels, past-card titles
+const TS_BODY_SMALL_SIZE = "text-[14px] leading-[1.22] min-[810px]:text-[16px]"; // event time/date supporting text
+const TS_CAPTION_SIZE = "text-[14px] leading-[1]"; // category chip pill
+const TS_OVERLINE_SIZE = "text-[12px]"; // weekday/month labels — already matches text-xs
+
 // This page's own accent palette — same structure/content as the new-design
-// events page, deliberately kept on this site's original MUI colors rather
-// than the new page's cream/rose design tokens.
-const RED = "#EA4335";
-const RED_HOVER = "#C5341F";
-const GREEN = "#168039";
+// events page, deliberately kept on this site's original colors rather than
+// the new page's cream/rose design tokens. MUI is retained only for the
+// modal Dialog (focus trap, escape handling, scroll lock); everything else
+// is plain markup so the page shares the site's font and visual weight.
+//
+// Colors are expressed as Tailwind arbitrary values so they stay literal:
+// red #EA4335 (accent), #C5341F (hover), green #168039 (past-card links).
+const PRIMARY_BUTTON_CLASSES = `inline-flex min-h-[44px] items-center gap-2 rounded-full bg-[#EA4335] px-6 py-2.5 font-medium text-white transition-colors duration-150 hover:bg-[#C5341F] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#EA4335] active:scale-[0.98] ${TS_LABEL_SIZE}`;
+
+const CAROUSEL_ARROW_CLASSES =
+  "absolute top-1/2 z-10 hidden h-11 w-11 -translate-y-1/2 items-center justify-center rounded-full bg-gray-100 text-gray-700 shadow-sm transition-colors duration-150 hover:bg-[#EA4335] hover:text-white focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#EA4335] sm:flex";
 
 interface EventsProps {
   events: EventItem[];
@@ -66,28 +80,24 @@ function CategoryAnchorButton({ slug }: { slug: string }) {
   };
 
   return (
-    <Box component="span" className="relative inline-flex shrink-0">
-      <Link
-        component="button"
+    <span className="relative inline-flex shrink-0">
+      <button
         type="button"
         onClick={handleClick}
         aria-label="Copy link to this section"
-        className="font-bold no-underline"
-        sx={{ color: "grey.400", fontSize: "1.25rem", "&:hover": { color: RED } }}
+        className={`inline-flex h-11 w-11 items-center justify-center font-bold text-gray-400 transition-colors duration-150 hover:text-[#EA4335] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#EA4335] ${TS_EDITORIAL_SIZE}`}
       >
         #
-      </Link>
+      </button>
       {copied && (
-        <Typography
-          component="span"
+        <span
           role="status"
-          className="absolute left-1/2 whitespace-nowrap rounded-full px-3 py-1 text-white"
-          sx={{ top: -34, transform: "translateX(-50%)", backgroundColor: "grey.900", fontSize: "0.75rem" }}
+          className={`absolute -top-9 left-1/2 -translate-x-1/2 whitespace-nowrap rounded-full bg-gray-900 px-3 py-1 text-white ${TS_CAPTION_SIZE}`}
         >
           Copied!
-        </Typography>
+        </span>
       )}
-    </Box>
+    </span>
   );
 }
 
@@ -95,40 +105,40 @@ function EventDescription({ text }: { text: string }) {
   const blocks = parseEventDescription(text);
 
   return (
-    <Box className="flex flex-col gap-3 break-words">
+    <div className="flex flex-col gap-3 break-words">
       {blocks.map((block, i) => {
         if (block.type === "hr") {
-          return <Box key={i} component="hr" className="border-gray-200" />;
+          return <hr key={i} className="border-gray-200" />;
         }
         if (block.type === "heading") {
           return (
-            <Typography key={i} variant="subtitle1" className="font-bold text-gray-900">
+            <p key={i} className={`font-bold text-gray-900 ${TS_EYEBROW_SIZE}`}>
               {renderInlineText(block.text, `h-${i}`)}
-            </Typography>
+            </p>
           );
         }
         if (block.type === "list") {
+          const ListTag = block.ordered ? "ol" : "ul";
           return (
-            <Box
+            <ListTag
               key={i}
-              component={block.ordered ? "ol" : "ul"}
-              className={block.ordered ? "list-decimal pl-5" : "list-disc pl-5"}
+              className={`${block.ordered ? "list-decimal pl-5" : "list-disc pl-5"} ${TS_BODY_SIZE}`}
             >
               {block.items.map((item, j) => (
-                <Typography key={j} component="li" variant="body2" className="text-gray-600">
+                <li key={j} className="text-gray-600">
                   {renderInlineText(item, `l-${i}-${j}`)}
-                </Typography>
+                </li>
               ))}
-            </Box>
+            </ListTag>
           );
         }
         return (
-          <Typography key={i} variant="body2" className="text-gray-600">
+          <p key={i} className={`text-gray-600 ${TS_BODY_SIZE}`}>
             {renderInlineText(block.text, `p-${i}`)}
-          </Typography>
+          </p>
         );
       })}
-    </Box>
+    </div>
   );
 }
 
@@ -139,81 +149,110 @@ function EventDetailsDialog({
   selected: SelectedEvent | null;
   onClose: () => void;
 }) {
+  // The body is split out so its hooks aren't called conditionally — `selected`
+  // toggles between null and set every time the dialog opens.
   if (!selected) return null;
+  return <EventDetailsDialogBody selected={selected} onClose={onClose} />;
+}
+
+function EventDetailsDialogBody({
+  selected,
+  onClose,
+}: {
+  selected: SelectedEvent;
+  onClose: () => void;
+}) {
   const { event, isPast } = selected;
-  const { day, month, year, full } = parseDateParts(event.date);
+  const {
+    parts: { day, month, year },
+    weekday,
+    time,
+    isoDate,
+  } = useEventDate(event);
   const { link: infoLink, label: infoLabel } = primaryEventLink(event, isPast);
   const title = displayTitle(event);
 
+  // MUI Dialog is kept for its focus trap, escape handling, and scroll lock;
+  // everything inside the paper is plain markup.
   return (
-    <Dialog open onClose={onClose} maxWidth="sm" fullWidth>
-      <Box className="relative flex aspect-[16/9] items-center justify-center overflow-hidden bg-gray-100">
-        <EventPreviewImage event={event} alt={title} className="h-full w-full object-contain" />
-        <IconButton
+    <Dialog
+      open
+      onClose={onClose}
+      maxWidth="sm"
+      fullWidth
+      PaperProps={{ sx: { borderRadius: "16px" } }}
+    >
+      {/* No fixed aspect ratio or box height here: YouTube thumbnails are
+          16:9, but flyer-style previews are often taller. Forcing w-full
+          with a height cap on the box clips the image via overflow-hidden
+          instead of shrinking it — cap only the img's own max-height and
+          let width follow the ratio, so the box sizes itself exactly to
+          the (uncropped) rendered image. */}
+      <div className="relative flex items-center justify-center bg-gray-100">
+        <EventPreviewImage
+          event={event}
+          alt={title}
+          className="max-h-[70vh] w-auto max-w-full object-contain"
+        />
+        <button
+          type="button"
           onClick={onClose}
           aria-label="Close"
-          sx={{
-            position: "absolute",
-            top: 12,
-            right: 12,
-            backgroundColor: "#fff",
-            "&:hover": { backgroundColor: RED, color: "#fff" },
-          }}
+          className="absolute right-3 top-3 inline-flex h-11 w-11 items-center justify-center rounded-full bg-white text-gray-700 shadow-sm transition-colors duration-150 hover:bg-[#EA4335] hover:text-white focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#EA4335]"
         >
           <CloseIcon />
-        </IconButton>
-      </Box>
+        </button>
+      </div>
       <DialogContent className="flex flex-col gap-4">
-        <time dateTime={event.date}>
-          <Typography
-            component="span"
-            className="block font-bold leading-none"
-            sx={{ color: RED, fontSize: "2rem" }}
+        <time dateTime={isoDate}>
+          <span
+            className={`block font-bold leading-none tracking-tight text-[#EA4335] ${TS_HEADING_SIZE}`}
           >
             {day}
-          </Typography>
-          <Typography component="span" variant="caption" className="block text-gray-500">
+          </span>
+          <span
+            className={`mt-1 block font-medium uppercase tracking-wide text-gray-500 ${TS_OVERLINE_SIZE}`}
+          >
             {month} {year}
-          </Typography>
+          </span>
         </time>
 
-        <Typography variant="h5" className="font-bold tracking-tight text-gray-900">
+        <h2 className={`font-bold tracking-tight text-gray-900 ${TS_SUBHEADING_SIZE}`}>
           {title}
-        </Typography>
+        </h2>
 
-        <Typography variant="body2" className="text-gray-500">
-          {full}
-          {event.time && <span> · {event.time}</span>}
-        </Typography>
+        {/* Day/month/year is already shown above in the date badge — this
+            line adds the info the badge doesn't carry (weekday, time)
+            instead of repeating the same date. */}
+        <p className={`text-gray-500 ${TS_BODY_SMALL_SIZE}`}>
+          {weekday}
+          {time && <span> · {time}</span>}
+        </p>
 
         {event.description && <EventDescription text={event.description} />}
       </DialogContent>
       {(infoLink || event.locationLink) && (
         <DialogActions className="flex-wrap gap-4 border-t border-gray-200 px-6 py-4">
           {infoLink && (
-            <Button
+            <a
               href={infoLink}
               target="_blank"
               rel="noopener noreferrer"
-              variant="contained"
-              endIcon={<ArrowForwardIcon fontSize="small" />}
-              sx={{
-                backgroundColor: RED,
-                "&:hover": { backgroundColor: RED_HOVER },
-              }}
+              className={PRIMARY_BUTTON_CLASSES}
             >
               {infoLabel}
-            </Button>
+              <ArrowRight size={16} />
+            </a>
           )}
           {event.locationLink && (
-            <Link
+            <a
               href={event.locationLink}
               target="_blank"
               rel="noopener noreferrer"
-              className="font-medium text-gray-600 hover:underline"
+              className="font-medium text-gray-600 underline-offset-4 transition-colors duration-150 hover:text-gray-900 hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#EA4335]"
             >
               View location
-            </Link>
+            </a>
           )}
         </DialogActions>
       )}
@@ -225,92 +264,108 @@ function EventDetailsDialog({
 
 function UpcomingEventCard({ item }: { item: UpcomingEvent }) {
   const { event, sectionDef } = item;
-  const { day, month } = parseDateParts(event.date);
-  const weekday = weekdayAbbrev(event.date);
+  const {
+    parts: { day, month },
+    weekday,
+    time,
+    isoDate,
+  } = useEventDate(event);
   const openModal = useContext(EventModalContext);
   const showPopup = hasMeaningfulDescription(event);
   const { link: infoLink, label: infoLabel } = primaryEventLink(event, false);
   const title = displayTitle(event);
+  const speakers = event.description ? getEventSpeakers(event.description) : [];
+  const teaser = speakers.length > 0
+    ? `Featuring ${formatSpeakerList(speakers)}`
+    : event.description
+      ? getDescriptionExcerpt(event.description)
+      : "";
 
   return (
-    <Box
-      className="flex flex-col gap-4 rounded-2xl p-5 sm:flex-row sm:items-center sm:gap-6"
-      sx={{ border: "1px solid", borderColor: "grey.200", borderLeft: `4px solid ${RED}` }}
-    >
-      <time dateTime={event.date} className="flex shrink-0 flex-col items-center">
-        <Typography variant="caption" className="text-gray-500">
+    <article className="flex flex-col gap-4 rounded-2xl border border-l-4 border-gray-200 border-l-[#EA4335] p-5 sm:flex-row sm:items-center sm:gap-6">
+      {/* Mobile-only lead image: on the stacked mobile layout this reads as
+          a proper card banner. At sm (row layout) there's no good place for
+          it alongside a centered date badge and a single text column, so it
+          drops entirely rather than being squeezed in as a small thumbnail. */}
+      <EventPreviewImage
+        event={event}
+        alt=""
+        className="aspect-video w-full rounded-xl bg-gray-100 object-cover sm:hidden"
+      />
+
+      {/* Fixed width (not shrink-to-fit) at the row breakpoint: without it,
+          this box sizes itself to whichever child is widest — a 2-digit day
+          number is wider than the weekday text, a 1-digit day number is
+          narrower — so every card's box ends up a different width and the
+          centered content lands at a different x per card. A shared fixed
+          width makes every card's date column line up like a table column. */}
+      <time dateTime={isoDate} className="flex shrink-0 flex-col items-center sm:w-16">
+        <span className={`font-medium uppercase tracking-wide text-gray-500 ${TS_OVERLINE_SIZE}`}>
           {weekday}
-        </Typography>
-        <Typography className="font-bold leading-none" sx={{ color: RED, fontSize: "1.75rem" }}>
+        </span>
+        <span
+          className={`font-bold leading-none tracking-tight text-[#EA4335] ${TS_HEADING_SIZE}`}
+        >
           {day}
-        </Typography>
-        <Typography variant="caption" className="text-gray-500">
+        </span>
+        <span className={`font-medium uppercase tracking-wide text-gray-500 ${TS_OVERLINE_SIZE}`}>
           {month}
-        </Typography>
+        </span>
       </time>
 
-      <Box className="min-w-0 flex-1">
-        <Chip
-          label={sectionDef.title}
-          size="small"
-          className="mb-1.5"
-          sx={{ backgroundColor: "grey.100", fontWeight: 600 }}
-        />
-        <Typography variant="subtitle1" className="truncate font-bold text-gray-900">
-          {title}
-        </Typography>
-        {event.time && (
-          <Typography variant="body2" className="text-gray-500">
-            {event.time}
-          </Typography>
-        )}
-      </Box>
+      <div className="min-w-0 flex-1">
+        <span
+          className={`mb-1.5 inline-flex items-center rounded-full bg-gray-100 px-2.5 py-1 font-semibold text-gray-700 ${TS_CAPTION_SIZE}`}
+        >
+          {sectionDef.title}
+        </span>
+        <h3 className={`truncate font-bold text-gray-900 ${TS_SUBHEADING_SIZE}`}>{title}</h3>
+        {time && <p className={`text-gray-500 ${TS_BODY_SMALL_SIZE}`}>{time}</p>}
+        {teaser && <p className={`mt-1 line-clamp-2 text-gray-500 ${TS_BODY_SMALL_SIZE}`}>{teaser}</p>}
+      </div>
 
-      <Box className="flex shrink-0 flex-wrap items-center gap-4">
+      <div className="flex shrink-0 flex-wrap items-center gap-4">
         {showPopup ? (
-          <Button
+          <button
+            type="button"
             onClick={() => openModal({ event, isPast: false })}
-            variant="contained"
-            endIcon={<ArrowForwardIcon fontSize="small" />}
-            sx={{ backgroundColor: RED, "&:hover": { backgroundColor: RED_HOVER } }}
+            className={PRIMARY_BUTTON_CLASSES}
           >
             More info
-          </Button>
+            <ArrowRight size={16} />
+          </button>
         ) : infoLink ? (
-          <Button
+          <a
             href={infoLink}
             target="_blank"
             rel="noopener noreferrer"
-            variant="contained"
-            endIcon={<ArrowForwardIcon fontSize="small" />}
-            sx={{ backgroundColor: RED, "&:hover": { backgroundColor: RED_HOVER } }}
+            className={PRIMARY_BUTTON_CLASSES}
           >
             {infoLabel}
-          </Button>
+            <ArrowRight size={16} />
+          </a>
         ) : (
-          <Typography variant="body2" className="text-gray-300">
-            —
-          </Typography>
+          <span className={`text-gray-400 ${TS_LABEL_SIZE}`}>—</span>
         )}
-      </Box>
-    </Box>
+      </div>
+    </article>
   );
 }
 
 function NoUpcomingEvents() {
   return (
-    <Box
-      className="rounded-2xl border border-dashed px-6 py-10 text-center"
-      sx={{ borderColor: "grey.300", backgroundColor: "grey.50" }}
-    >
-      <Typography variant="body1" className="text-gray-600">
+    <div className="rounded-2xl border border-dashed border-gray-300 bg-gray-50 px-6 py-10 text-center">
+      <p className={`text-gray-600 ${TS_BODY_SIZE}`}>
         No upcoming events right now — check back soon, or{" "}
-        <Link href="#past-events" sx={{ color: RED }} className="hover:underline">
+        <a
+          href="#past-events"
+          className="font-medium text-[#EA4335] underline-offset-4 transition-colors duration-150 hover:text-[#C5341F] hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#EA4335]"
+        >
           browse recordings below
-        </Link>
+        </a>
         .
-      </Typography>
-    </Box>
+      </p>
+    </div>
   );
 }
 
@@ -318,10 +373,10 @@ function UpcomingEventsSection({ events }: { events: EventItem[] }) {
   const { items, hasMore } = getUpcomingEvents(events, UPCOMING_WINDOW_DAYS);
 
   return (
-    <Box component="section" aria-label="Upcoming Events">
-      <Typography variant="h4" className="mb-8 font-bold tracking-tight text-gray-900">
+    <section aria-label="Upcoming Events">
+      <h2 className={`mb-8 font-bold tracking-tight text-gray-900 ${TS_EDITORIAL_SIZE}`}>
         Upcoming Events
-      </Typography>
+      </h2>
 
       {items.length === 0 ? (
         <NoUpcomingEvents />
@@ -334,64 +389,57 @@ function UpcomingEventsSection({ events }: { events: EventItem[] }) {
       )}
 
       {hasMore && (
-        <Typography variant="body2" className="mt-6 text-gray-500">
+        <p className={`mt-6 text-gray-500 ${TS_BODY_SMALL_SIZE}`}>
           More events are already scheduled beyond the next {UPCOMING_WINDOW_DAYS} days.
-        </Typography>
+        </p>
       )}
-    </Box>
+    </section>
   );
 }
 
 // ---------- Past Events ----------
 
 function PastEventCard({ event }: { event: EventItem }) {
-  const { full } = parseDateParts(event.date);
+  const {
+    parts: { full },
+  } = useEventDate(event);
   const openModal = useContext(EventModalContext);
   const showPopup = hasMeaningfulDescription(event);
   const { link: infoLink, label: infoLabel } = primaryEventLink(event, true);
   const title = displayTitle(event);
 
   return (
-    <Card className="flex h-full flex-col overflow-hidden rounded-2xl" sx={{ border: "1px solid", borderColor: "grey.200" }}>
-      <Box className="flex aspect-video items-center justify-center overflow-hidden bg-gray-100">
+    <article className="flex h-full flex-col overflow-hidden rounded-2xl border border-gray-200 bg-white transition-[border-color,box-shadow] duration-150 hover:border-gray-300 hover:shadow-sm">
+      <div className="flex aspect-video items-center justify-center overflow-hidden bg-gray-100">
         <EventPreviewImage event={event} alt={title} className="h-full w-full object-contain" />
-      </Box>
-      <Box className="flex flex-1 flex-col gap-2 p-4">
-        <Typography variant="body2" className="text-gray-500">
-          {full}
-        </Typography>
-        <Typography variant="subtitle2" className="line-clamp-2 font-bold text-gray-900">
-          {title}
-        </Typography>
-        <Box className="mt-auto pt-2">
+      </div>
+      <div className="flex flex-1 flex-col gap-2 p-4">
+        <p className={`text-gray-500 ${TS_BODY_SMALL_SIZE}`}>{full}</p>
+        <h3 className={`line-clamp-2 font-bold text-gray-900 ${TS_LABEL_SIZE}`}>{title}</h3>
+        <div className="mt-auto pt-2">
           {showPopup ? (
-            <Link
-              component="button"
+            <button
               type="button"
               onClick={() => openModal({ event, isPast: true })}
-              className="font-medium hover:underline"
-              sx={{ color: GREEN }}
+              className={`font-medium text-[#168039] underline-offset-4 transition-colors duration-150 hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#EA4335] ${TS_LABEL_SIZE}`}
             >
               More info
-            </Link>
+            </button>
           ) : infoLink ? (
-            <Link
+            <a
               href={infoLink}
               target="_blank"
               rel="noopener noreferrer"
-              className="font-medium hover:underline"
-              sx={{ color: GREEN }}
+              className={`font-medium text-[#168039] underline-offset-4 transition-colors duration-150 hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#EA4335] ${TS_LABEL_SIZE}`}
             >
               {infoLabel}
-            </Link>
+            </a>
           ) : (
-            <Typography variant="body2" className="text-gray-300">
-              —
-            </Typography>
+            <span className={`text-gray-400 ${TS_LABEL_SIZE}`}>—</span>
           )}
-        </Box>
-      </Box>
-    </Card>
+        </div>
+      </div>
+    </article>
   );
 }
 
@@ -405,69 +453,55 @@ function PastEventsCarousel({ events }: { events: EventItem[] }) {
     useCarouselScroll(events.length);
 
   return (
-    <Box className="relative">
+    <div className="relative">
       {canScrollLeft && (
-        <IconButton
+        <button
+          type="button"
           onClick={() => scrollByCard(-1)}
           aria-label="Show earlier past events"
-          sx={{
-            display: { xs: "none", sm: "flex" },
-            position: "absolute",
-            top: "50%",
-            left: -12,
-            zIndex: 10,
-            transform: "translateY(-50%)",
-            width: 44,
-            height: 44,
-            padding: 0,
-            backgroundColor: "grey.100",
-            boxShadow: 1,
-            "&:hover": { backgroundColor: RED, color: "#fff" },
-          }}
+          className={`${CAROUSEL_ARROW_CLASSES} -left-3 rotate-180`}
         >
-          <ChevronLeftIcon />
-        </IconButton>
+          <ArrowRight size={18} />
+        </button>
       )}
 
-      <Box
+      <div
         ref={trackRef}
         onScroll={updateScrollState}
         role="region"
         aria-roledescription="carousel"
         aria-label="Past events"
         tabIndex={0}
-        className="flex gap-4 overflow-x-auto motion-safe:scroll-smooth motion-reduce:scroll-auto focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[#EA4335] [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+        className="flex gap-4 overflow-x-auto [-ms-overflow-style:none] [scrollbar-width:none] focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[#EA4335] motion-safe:scroll-smooth motion-reduce:scroll-auto [&::-webkit-scrollbar]:hidden"
       >
         {events.map((event) => (
-          <div key={event.id} data-carousel-card className="w-[68%] shrink-0 min-[640px]:w-[42%] min-[900px]:w-[29%]">
+          <div
+            key={event.id}
+            data-carousel-card
+            className="w-[68%] shrink-0 min-[640px]:w-[42%] min-[900px]:w-[29%]"
+          >
             <PastEventCard event={event} />
           </div>
         ))}
-      </Box>
+      </div>
 
       {canScrollRight && (
-        <IconButton
-          onClick={() => scrollByCard(1)}
-          aria-label="Show more past events"
-          sx={{
-            display: { xs: "none", sm: "flex" },
-            position: "absolute",
-            top: "50%",
-            right: -12,
-            zIndex: 10,
-            transform: "translateY(-50%)",
-            width: 44,
-            height: 44,
-            padding: 0,
-            backgroundColor: "grey.100",
-            boxShadow: 1,
-            "&:hover": { backgroundColor: RED, color: "#fff" },
-          }}
-        >
-          <ChevronRightIcon />
-        </IconButton>
+        <>
+          <div
+            aria-hidden="true"
+            className="pointer-events-none absolute inset-y-0 right-0 w-16 bg-gradient-to-l from-white to-transparent"
+          />
+          <button
+            type="button"
+            onClick={() => scrollByCard(1)}
+            aria-label="Show more past events"
+            className={`${CAROUSEL_ARROW_CLASSES} -right-3`}
+          >
+            <ArrowRight size={18} />
+          </button>
+        </>
       )}
-    </Box>
+    </div>
   );
 }
 
@@ -481,45 +515,95 @@ function PastEventsCategorySection({ section }: { section: EventSection }) {
   if (past.length === 0) return null;
 
   return (
-    <Box
-      component="section"
+    <section
       id={def.key}
       aria-label={def.title}
-      className="border-t pt-12"
-      sx={{ borderColor: "grey.200", scrollMarginTop: "96px" }}
+      className="scroll-mt-24 border-t border-gray-200 pt-12"
     >
-      <Box className="flex items-start justify-between gap-4">
-        <Box>
-          <Typography variant="h5" className="mb-1 flex items-center gap-2 font-bold tracking-tight text-gray-900">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h3
+            className={`mb-1 flex items-center gap-2 font-bold tracking-tight text-gray-900 ${TS_EDITORIAL_SIZE}`}
+          >
             <CategoryAnchorButton slug={def.key} />
             {def.title}
-          </Typography>
-          <Typography variant="body2" className="text-gray-500">
-            {def.subtitle}
-          </Typography>
-        </Box>
-        <IconButton
+          </h3>
+          <p className={`text-gray-500 ${TS_BODY_SIZE}`}>{def.subtitle}</p>
+        </div>
+        <button
+          type="button"
           onClick={() => setExpanded((prev) => !prev)}
           aria-expanded={expanded}
           aria-label={expanded ? "Collapse section" : "Expand section"}
-          className="shrink-0"
-          sx={{
-            backgroundColor: "grey.100",
-            "&:hover": { backgroundColor: RED, color: "#fff" },
-          }}
+          className="inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-gray-100 text-gray-700 transition-colors duration-150 hover:bg-[#EA4335] hover:text-white focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#EA4335]"
         >
-          <ExpandMoreIcon
-            sx={{ transform: expanded ? "rotate(180deg)" : "rotate(0deg)", transition: "0.2s" }}
-          />
-        </IconButton>
-      </Box>
+          <ChevronDown expanded={expanded} size={18} />
+        </button>
+      </div>
 
       {expanded && (
-        <Box className="mt-8">
+        <div className="mt-8">
           <PastEventsCarousel events={past} />
-        </Box>
+        </div>
       )}
-    </Box>
+    </section>
+  );
+}
+
+// ---------- Page states ----------
+
+// Mirrors the real page shape (upcoming rows, then a past-events card row) so
+// the layout doesn't jump when content arrives.
+function LoadingSkeleton() {
+  return (
+    <div aria-hidden="true">
+      <div className="mb-8 h-8 w-56 animate-pulse rounded bg-gray-100" />
+      <div className="flex flex-col gap-4">
+        {[...Array(2)].map((_, index) => (
+          <div
+            key={`upcoming-skeleton-${index}`}
+            className="flex items-center gap-6 rounded-2xl border border-gray-200 p-5"
+          >
+            <div className="h-14 w-10 shrink-0 animate-pulse rounded bg-gray-100" />
+            <div className="flex-1 space-y-2">
+              <div className="h-4 w-24 animate-pulse rounded bg-gray-100" />
+              <div className="h-4 w-2/3 animate-pulse rounded bg-gray-100" />
+            </div>
+            <div className="hidden h-11 w-32 shrink-0 animate-pulse rounded-full bg-gray-100 sm:block" />
+          </div>
+        ))}
+      </div>
+      <div className="mt-14 border-t border-gray-200 pt-12">
+        <div className="mb-8 h-7 w-48 animate-pulse rounded bg-gray-100" />
+        <div className="flex gap-4 overflow-hidden">
+          {[...Array(4)].map((_, index) => (
+            <div
+              key={`past-skeleton-${index}`}
+              className="w-[68%] shrink-0 min-[640px]:w-[42%] min-[900px]:w-[29%]"
+            >
+              <div className="overflow-hidden rounded-2xl border border-gray-200">
+                <div className="aspect-video animate-pulse bg-gray-100" />
+                <div className="space-y-2 p-4">
+                  <div className="h-3 w-24 animate-pulse rounded bg-gray-100" />
+                  <div className="h-4 w-3/4 animate-pulse rounded bg-gray-100" />
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function EmptyState() {
+  return (
+    <div className="rounded-2xl border border-dashed border-gray-300 bg-gray-50 px-6 py-16 text-center">
+      <p className={`mb-2 font-bold text-gray-900 ${TS_BODY_LARGE_SIZE}`}>No events found</p>
+      <p className={`text-gray-500 ${TS_BODY_SIZE}`}>
+        There are no events available at the moment. Check back later!
+      </p>
+    </div>
   );
 }
 
@@ -529,7 +613,6 @@ export default function Events({
 }: EventsProps) {
   const [events, setEvents] = useState<EventItem[]>(initialEvents);
   const [loading, setLoading] = useState(initialLoading);
-  const [showEvents, setShowEvents] = useState(initialEvents.length > 0);
   const [selectedEvent, setSelectedEvent] = useState<SelectedEvent | null>(null);
 
   const fetchEvents = async () => {
@@ -546,7 +629,6 @@ export default function Events({
       if (response.ok) {
         const newEvents: EventItem[] = await response.json();
         setEvents(newEvents);
-        setShowEvents(newEvents.length > 0);
       }
     } catch {
       /*
@@ -564,9 +646,6 @@ export default function Events({
       fetchEvents();
     } else {
       setLoading(false);
-      if (initialEvents.length > 0) {
-        setShowEvents(true);
-      }
     }
   }, []);
 
@@ -587,67 +666,31 @@ export default function Events({
   return (
     <EventModalContext.Provider value={setSelectedEvent}>
       <div className="mx-auto max-w-6xl px-4 py-10">
-        {loading && events.length === 0 && (
-          <div className="space-y-6">
-            {[...Array(3)].map((_, index) => (
-              <Box
-                key={`skeleton-${index}`}
-                className="animate-pulse rounded-lg bg-gray-100 p-6 shadow"
-              >
-                <div className="mb-2 h-4 w-2/3 rounded bg-gray-200"></div>
-                <div className="mb-2 h-3 w-1/3 rounded bg-gray-200"></div>
-                <div className="h-24 w-full rounded bg-gray-200"></div>
-              </Box>
-            ))}
-          </div>
-        )}
+        {loading && events.length === 0 && <LoadingSkeleton />}
 
-        {!loading && events.length === 0 && (
-          <Fade in={!loading && events.length === 0}>
-            <Box className="py-12 text-center">
-              <EventBusyIcon
-                sx={{
-                  fontSize: 64,
-                  color: "text.secondary",
-                  marginBottom: 2,
-                  opacity: 0.5,
-                }}
-              />
-              <Typography variant="h6" className="mb-2 text-gray-700">
-                No events found
-              </Typography>
-              <Typography variant="body2" className="text-gray-500">
-                There are no events available at the moment. Check back later!
-              </Typography>
-            </Box>
-          </Fade>
-        )}
+        {!loading && events.length === 0 && <EmptyState />}
 
         {events.length > 0 && (
-          <Fade in={showEvents} timeout={500}>
-            <div>
-              <UpcomingEventsSection events={events} />
+          <div>
+            <UpcomingEventsSection events={events} />
 
-              {hasPastEvents && (
-                <Box
-                  id="past-events"
-                  component="section"
-                  className="border-t pt-14"
-                  sx={{ borderColor: "grey.200", scrollMarginTop: "96px" }}
-                >
-                  <Typography variant="h4" className="font-bold tracking-tight text-gray-900">
-                    Past Events
-                  </Typography>
-                </Box>
-              )}
+            {hasPastEvents && (
+              <section
+                id="past-events"
+                className="mt-14 scroll-mt-24 border-t border-gray-200 pt-14"
+              >
+                <h2 className={`font-bold tracking-tight text-gray-900 ${TS_EDITORIAL_SIZE}`}>
+                  Past Events
+                </h2>
+              </section>
+            )}
 
-              <div className="mt-12 space-y-12">
-                {sections.map((section) => (
-                  <PastEventsCategorySection key={section.def.key} section={section} />
-                ))}
-              </div>
+            <div className="mt-12 space-y-12">
+              {sections.map((section) => (
+                <PastEventsCategorySection key={section.def.key} section={section} />
+              ))}
             </div>
-          </Fade>
+          </div>
         )}
       </div>
       <EventDetailsDialog selected={selectedEvent} onClose={() => setSelectedEvent(null)} />

--- a/src/components/FAQAccordion.tsx
+++ b/src/components/FAQAccordion.tsx
@@ -23,7 +23,13 @@ export default function FAQAccordion({ question, answer }: FAQAccordionProps) {
         {typeof answer === "string" ? (
           <Typography>{answer}</Typography>
         ) : Array.isArray(answer) ? (
-          <RichTextRenderer richText={answer} />
+          <RichTextRenderer
+            richText={answer}
+            linkClassName="text-blue-600"
+            mutedTextClassName="text-gray-500"
+            accentTextClassName="text-red-600"
+            codeClassName="bg-gray-100"
+          />
         ) : (
           answer
         )}

--- a/src/components/IdeasWithTabs.tsx
+++ b/src/components/IdeasWithTabs.tsx
@@ -161,6 +161,10 @@ export default function IdeasWithTabs({
                 <RichTextRenderer
                   richText={activeIdea.richTextDescription}
                   className="!font-sans"
+                  linkClassName="text-blue-600"
+                  mutedTextClassName="text-gray-500"
+                  accentTextClassName="text-red-600"
+                  codeClassName="bg-gray-100"
                 />
               </div>
 

--- a/src/components/RichTextRenderer.tsx
+++ b/src/components/RichTextRenderer.tsx
@@ -1,7 +1,14 @@
 import React from "react";
 import type { RichTextSegment, RichTextRendererProps, NotionRichText } from "../types/richText";
 
-const RichTextRenderer: React.FC<RichTextRendererProps> = ({ richText, className = "" }) => {
+const RichTextRenderer: React.FC<RichTextRendererProps> = ({
+  richText,
+  className = "",
+  linkClassName = "text-brand",
+  mutedTextClassName = "text-ink-secondary",
+  accentTextClassName = "text-brand",
+  codeClassName = "bg-sand",
+}) => {
   // Handle both direct array and Notion API response format
   const segments: RichTextSegment[] = Array.isArray(richText)
     ? richText
@@ -161,11 +168,11 @@ const RichTextRenderer: React.FC<RichTextRendererProps> = ({ richText, className
       style.textDecoration = (style.textDecoration || "") + " underline";
     }
     if (annotations.code) {
-      classes.push("font-mono bg-sand px-1 py-0.5 rounded text-sm");
+      classes.push(`font-mono ${codeClassName} px-1 py-0.5 rounded text-sm`);
     }
     if (annotations.color && annotations.color !== "default") {
       const colorMap: Record<string, string> = {
-        gray: "text-ink-secondary",
+        gray: mutedTextClassName,
         brown: "text-amber-800",
         orange: "text-orange-600",
         yellow: "text-yellow-600",
@@ -173,7 +180,7 @@ const RichTextRenderer: React.FC<RichTextRendererProps> = ({ richText, className
         blue: "text-blue-600",
         purple: "text-purple-600",
         pink: "text-pink-600",
-        red: "text-brand",
+        red: accentTextClassName,
       };
       if (colorMap[annotations.color]) {
         classes.push(colorMap[annotations.color]);
@@ -191,7 +198,7 @@ const RichTextRenderer: React.FC<RichTextRendererProps> = ({ richText, className
           target={linkUrl.startsWith("http") ? "_blank" : undefined}
           rel={linkUrl.startsWith("http") ? "noopener noreferrer" : undefined}
           style={style}
-          className={`text-brand hover:underline ${classes.join(" ")}`}
+          className={`${linkClassName} hover:underline ${classes.join(" ")}`}
         >
           {content}
         </a>

--- a/src/components/UpcomingEventPopup.tsx
+++ b/src/components/UpcomingEventPopup.tsx
@@ -1,0 +1,147 @@
+import { useEffect, useState } from "react";
+import { primaryEventLink, type EventItem } from "../store/eventsClient";
+import { displayTitle, getUpcomingEvents } from "../utils/eventSections";
+import { EventPreviewImage } from "./events/EventPreviewImage";
+import { ArrowRight, CloseIcon, useEventDate } from "./events/eventsShared";
+
+const SHOW_DELAY_MS = 2000;
+const UPCOMING_WINDOW_DAYS = 60;
+const DISMISSED_KEY = "dismissed_event_popup_id";
+
+function track(name: string, event: EventItem) {
+  if (typeof window.plausible === "undefined") return;
+  window.plausible(name, { props: { event_id: event.id, event_title: event.title } });
+}
+
+function PopupCard({
+  event,
+  entered,
+  onClose,
+}: {
+  event: EventItem;
+  entered: boolean;
+  onClose: () => void;
+}) {
+  const {
+    parts: { day, month },
+    weekday,
+    time,
+  } = useEventDate(event);
+  const { link, label } = primaryEventLink(event, false);
+  const title = displayTitle(event);
+
+  return (
+    <div
+      role="dialog"
+      aria-label="Upcoming event"
+      className={`fixed bottom-4 left-4 right-4 z-40 mx-auto flex max-w-sm flex-row items-center gap-3 overflow-hidden rounded-2xl border border-gray-200 bg-white p-3 shadow-lg transition-all duration-300 ease-out sm:left-auto sm:right-6 sm:mx-0 sm:flex-col sm:items-stretch sm:gap-0 sm:p-0 motion-reduce:transition-none ${entered ? "translate-y-0 opacity-100" : "translate-y-4 opacity-0"}`}
+    >
+      <div className="relative shrink-0 sm:shrink">
+        <EventPreviewImage
+          event={event}
+          alt=""
+          className="h-14 w-14 rounded-lg bg-gray-100 object-cover sm:aspect-video sm:h-auto sm:w-full sm:rounded-none"
+        />
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Dismiss"
+          className="absolute right-2 top-2 hidden h-8 w-8 items-center justify-center rounded-full bg-white text-gray-700 shadow-sm transition-colors duration-150 hover:bg-[#EA4335] hover:text-white focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#EA4335] sm:flex"
+        >
+          <CloseIcon size={16} />
+        </button>
+      </div>
+
+      <div className="min-w-0 flex-1 sm:flex-none sm:p-4">
+        <p className="truncate text-xs font-medium uppercase tracking-wide text-gray-500">
+          {weekday}, {month} {day}
+          {time ? ` · ${time}` : ""}
+        </p>
+        <h3 className="truncate font-bold text-gray-900">{title}</h3>
+        <div className="mt-2 flex items-center gap-3">
+          {link && (
+            <a
+              href={link}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() => track("Event Popup Register Click", event)}
+              className="inline-flex items-center gap-1 rounded-full bg-[#EA4335] px-3 py-1.5 text-sm font-medium text-white transition-colors duration-150 hover:bg-[#C5341F] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#EA4335]"
+            >
+              {label}
+              <ArrowRight size={14} />
+            </a>
+          )}
+          <a
+            href="/events"
+            onClick={() => track("Event Popup All Events Click", event)}
+            className="hidden text-sm font-medium text-gray-600 underline-offset-4 hover:text-gray-900 hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#EA4335] sm:inline"
+          >
+            All events
+          </a>
+        </div>
+      </div>
+
+      <button
+        type="button"
+        onClick={onClose}
+        aria-label="Dismiss"
+        className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-gray-500 transition-colors duration-150 hover:bg-gray-100 hover:text-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#EA4335] sm:hidden"
+      >
+        <CloseIcon size={16} />
+      </button>
+    </div>
+  );
+}
+
+// A dismissible bottom-corner card promoting the soonest upcoming event, to
+// drive event sign-ups from the homepage without blocking the page like a
+// center modal would. Shows once per event: dismissing it is remembered per
+// event id, so it won't nag on repeat visits, but a *different* upcoming
+// event will still get its own chance to show.
+export default function UpcomingEventPopup() {
+  const [event, setEvent] = useState<EventItem | null>(null);
+  const [entered, setEntered] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    fetch("/api/events")
+      .then((r) => (r.ok ? r.json() : []))
+      .then((events: EventItem[]) => {
+        if (cancelled) return;
+        const { items } = getUpcomingEvents(events, UPCOMING_WINDOW_DAYS);
+        const next = items[0]?.event;
+        if (!next || !primaryEventLink(next, false).link) return;
+        if (localStorage.getItem(DISMISSED_KEY) === next.id) return;
+
+        window.setTimeout(() => {
+          if (cancelled) return;
+          setEvent(next);
+          track("Event Popup Shown", next);
+          // Mount first (off-screen/transparent per its initial classes), then
+          // flip to the entered state on the next frame so the browser has a
+          // "before" state to transition from — setting both at once would
+          // just paint the final state directly with no visible motion.
+          requestAnimationFrame(() => requestAnimationFrame(() => setEntered(true)));
+        }, SHOW_DELAY_MS);
+      })
+      .catch(() => {
+        // ponytail: silent fail — a promo popup isn't worth surfacing an error for
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (!event) return null;
+
+  const handleClose = () => {
+    localStorage.setItem(DISMISSED_KEY, event.id);
+    track("Event Popup Dismissed", event);
+    setEntered(false);
+    window.setTimeout(() => setEvent(null), 300);
+  };
+
+  return <PopupCard event={event} entered={entered} onClose={handleClose} />;
+}

--- a/src/components/events/EventModal.tsx
+++ b/src/components/events/EventModal.tsx
@@ -3,7 +3,7 @@ import { primaryEventLink } from "../../store/eventsClient";
 import { displayTitle } from "../../utils/eventSections";
 import { parseEventDescription, renderInlineText } from "../../utils/eventDescription";
 import { useBodyScrollLock } from "../../utils/useBodyScrollLock";
-import { ArrowRight, CloseIcon, parseDateParts, type SelectedEvent } from "./eventsShared";
+import { ArrowRight, CloseIcon, useEventDate, type SelectedEvent } from "./eventsShared";
 import { EventPreviewImage } from "./EventPreviewImage";
 
 function EventDescription({ text }: { text: string }) {
@@ -43,7 +43,12 @@ interface EventModalProps {
 
 export function EventModal({ selected, onClose }: EventModalProps) {
   const { event, isPast } = selected;
-  const { day, month, year, full } = parseDateParts(event.date);
+  const {
+    parts: { day, month, year },
+    weekday,
+    time,
+    isoDate,
+  } = useEventDate(event);
   const { link: infoLink, label: infoLabel } = primaryEventLink(event, isPast);
   const title = displayTitle(event);
 
@@ -74,8 +79,18 @@ export function EventModal({ selected, onClose }: EventModalProps) {
         aria-label={title}
       >
         <div className="overflow-y-auto overscroll-y-contain">
-          <div className="relative flex aspect-[16/9] items-center justify-center overflow-hidden bg-sand">
-            <EventPreviewImage event={event} alt={title} className="h-full w-full object-contain" />
+          {/* No fixed aspect ratio or box height here: YouTube thumbnails
+              are 16:9, but flyer-style previews are often taller. Forcing
+              w-full with a height cap on the box clips the image via
+              overflow-hidden instead of shrinking it — cap only the img's
+              own max-height and let width follow the ratio, so the box
+              sizes itself exactly to the (uncropped) rendered image. */}
+          <div className="relative flex items-center justify-center bg-sand">
+            <EventPreviewImage
+              event={event}
+              alt={title}
+              className="max-h-[70vh] w-auto max-w-full object-contain"
+            />
             <button
               type="button"
               onClick={onClose}
@@ -87,7 +102,7 @@ export function EventModal({ selected, onClose }: EventModalProps) {
           </div>
 
           <div className="flex flex-col gap-4 p-6 min-[640px]:p-8">
-            <time dateTime={event.date}>
+            <time dateTime={isoDate}>
               <span className="ts-heading block leading-none text-brand">{day}</span>
               <span className="ts-overline block text-ink-secondary">
                 {month} {year}
@@ -96,9 +111,12 @@ export function EventModal({ selected, onClose }: EventModalProps) {
 
             <h2 className="ts-subheading text-ink">{title}</h2>
 
+            {/* Day/month/year is already shown above in the date badge —
+                this line adds the info the badge doesn't carry (weekday,
+                time) instead of repeating the same date. */}
             <p className="ts-body-small text-ink-secondary">
-              {full}
-              {event.time && <span> · {event.time}</span>}
+              {weekday}
+              {time && <span> · {time}</span>}
             </p>
 
             {event.description && <EventDescription text={event.description} />}

--- a/src/components/events/EventPreviewImage.tsx
+++ b/src/components/events/EventPreviewImage.tsx
@@ -14,7 +14,8 @@ interface EventPreviewImageProps {
 // Shared by both events pages (the legacy MUI page imports this directly
 // too — plain <img>, no MUI-specific behavior needed).
 //
-// For a YouTube-backed preview (Community Calls), maxresdefault.jpg doesn't
+// For a YouTube-backed preview (any event with a recording/stream link),
+// maxresdefault.jpg doesn't
 // 404 when missing — YouTube serves a 120x90 grey placeholder with a 200
 // status — so failure is detected on load via its fixed size, not onError,
 // and only then do we drop to the guaranteed-to-exist hqdefault.jpg.

--- a/src/components/events/EventsNew.tsx
+++ b/src/components/events/EventsNew.tsx
@@ -1,7 +1,12 @@
 import { useEffect, useState } from "react";
 import type { EventItem } from "../../store/eventsClient";
 import { groupIntoSections } from "../../utils/eventSections";
-import { EventModalContext, type SelectedEvent } from "./eventsShared";
+import {
+  EventModalContext,
+  useVisitorZoneReady,
+  VisitorZoneContext,
+  type SelectedEvent,
+} from "./eventsShared";
 import { EventModal } from "./EventModal";
 import { UpcomingEventsSection } from "./UpcomingEvents";
 import { PastEventsCategorySection } from "./PastEventsCarousel";
@@ -41,6 +46,9 @@ export default function EventsNew({ initialEvents = [] }: EventsNewProps) {
   const [events, setEvents] = useState<EventItem[]>(initialEvents);
   const [loading, setLoading] = useState(initialEvents.length === 0);
   const [selectedEvent, setSelectedEvent] = useState<SelectedEvent | null>(null);
+  // This island is mounted `client:load`, so it server-renders first. Event
+  // times only become the visitor's own after mount — see VisitorZoneContext.
+  const visitorZoneReady = useVisitorZoneReady();
 
   useEffect(() => {
     if (initialEvents.length > 0) return;
@@ -69,32 +77,37 @@ export default function EventsNew({ initialEvents = [] }: EventsNewProps) {
   const hasPastEvents = sections.some((section) => section.past.length > 0);
 
   return (
-    <EventModalContext.Provider value={setSelectedEvent}>
-      <div className="pb-16 min-[810px]:pb-24">
-        {loading ? (
-          <LoadingSkeleton />
-        ) : events.length === 0 ? (
-          <EmptyState />
-        ) : (
-          <>
-            <UpcomingEventsSection events={events} />
+    <VisitorZoneContext.Provider value={visitorZoneReady}>
+      <EventModalContext.Provider value={setSelectedEvent}>
+        <div className="pb-16 min-[810px]:pb-24">
+          {loading ? (
+            <LoadingSkeleton />
+          ) : events.length === 0 ? (
+            <EmptyState />
+          ) : (
+            <>
+              <UpcomingEventsSection events={events} />
 
-            {hasPastEvents && (
-              <div id="past-events" className="scroll-mt-24 bg-page px-6 pt-14 min-[810px]:px-10 min-[810px]:pt-20">
-                <div className="mx-auto max-w-[1400px] border-t border-ink-divider pt-14 min-[810px]:pt-16">
-                  <h2 className="ts-editorial text-ink">Past Events</h2>
+              {hasPastEvents && (
+                <div
+                  id="past-events"
+                  className="scroll-mt-24 bg-page px-6 pt-14 min-[810px]:px-10 min-[810px]:pt-20"
+                >
+                  <div className="mx-auto max-w-[1400px] border-t border-ink-divider pt-14 min-[810px]:pt-16">
+                    <h2 className="ts-editorial text-ink">Past Events</h2>
+                  </div>
                 </div>
-              </div>
-            )}
-            {sections.map((section) => (
-              <PastEventsCategorySection key={section.def.key} section={section} />
-            ))}
-          </>
+              )}
+              {sections.map((section) => (
+                <PastEventsCategorySection key={section.def.key} section={section} />
+              ))}
+            </>
+          )}
+        </div>
+        {selectedEvent && (
+          <EventModal selected={selectedEvent} onClose={() => setSelectedEvent(null)} />
         )}
-      </div>
-      {selectedEvent && (
-        <EventModal selected={selectedEvent} onClose={() => setSelectedEvent(null)} />
-      )}
-    </EventModalContext.Provider>
+      </EventModalContext.Provider>
+    </VisitorZoneContext.Provider>
   );
 }

--- a/src/components/events/PastEventsCarousel.tsx
+++ b/src/components/events/PastEventsCarousel.tsx
@@ -1,13 +1,17 @@
 import { useContext, useState } from "react";
-import { hasMeaningfulDescription, primaryEventLink, type EventItem } from "../../store/eventsClient";
+import {
+  hasMeaningfulDescription,
+  primaryEventLink,
+  type EventItem,
+} from "../../store/eventsClient";
 import { displayTitle, type EventSection } from "../../utils/eventSections";
 import {
   ArrowRight,
   CategoryAnchorButton,
   ChevronDown,
   EventModalContext,
-  parseDateParts,
   useCarouselScroll,
+  useEventDate,
 } from "./eventsShared";
 import { EventPreviewImage } from "./EventPreviewImage";
 
@@ -16,7 +20,9 @@ interface PastEventCardProps {
 }
 
 function PastEventCard({ event }: PastEventCardProps) {
-  const { full } = parseDateParts(event.date);
+  const {
+    parts: { full },
+  } = useEventDate(event);
   const openModal = useContext(EventModalContext);
   const showPopup = hasMeaningfulDescription(event);
   const { link: infoLink, label: infoLabel } = primaryEventLink(event, true);
@@ -24,7 +30,11 @@ function PastEventCard({ event }: PastEventCardProps) {
   return (
     <article className="flex h-full flex-col overflow-hidden rounded-[16px] border border-butter bg-page">
       <div className="flex aspect-video items-center justify-center overflow-hidden bg-sand">
-        <EventPreviewImage event={event} alt={displayTitle(event)} className="h-full w-full object-contain" />
+        <EventPreviewImage
+          event={event}
+          alt={displayTitle(event)}
+          className="h-full w-full object-contain"
+        />
       </div>
       <div className="flex flex-1 flex-col gap-2 p-4">
         <p className="ts-body-small text-ink-secondary">{full}</p>
@@ -92,7 +102,7 @@ function PastEventsCarousel({ events }: PastEventsCarouselProps) {
         aria-roledescription="carousel"
         aria-label="Past events"
         tabIndex={0}
-        className="flex gap-4 overflow-x-auto motion-safe:scroll-smooth motion-reduce:scroll-auto focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-brand [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+        className="flex gap-4 overflow-x-auto [-ms-overflow-style:none] [scrollbar-width:none] focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-brand motion-safe:scroll-smooth motion-reduce:scroll-auto [&::-webkit-scrollbar]:hidden"
       >
         {events.map((event) => (
           <div

--- a/src/components/events/UpcomingEvents.tsx
+++ b/src/components/events/UpcomingEvents.tsx
@@ -1,7 +1,13 @@
 import { useContext } from "react";
-import { hasMeaningfulDescription, primaryEventLink, type EventItem } from "../../store/eventsClient";
+import {
+  hasMeaningfulDescription,
+  primaryEventLink,
+  type EventItem,
+} from "../../store/eventsClient";
 import { displayTitle, getUpcomingEvents, type UpcomingEvent } from "../../utils/eventSections";
-import { ArrowRight, EventModalContext, parseDateParts, weekdayAbbrev } from "./eventsShared";
+import { formatSpeakerList, getDescriptionExcerpt, getEventSpeakers } from "../../utils/eventDescription";
+import { ArrowRight, EventModalContext, useEventDate } from "./eventsShared";
+import { EventPreviewImage } from "./EventPreviewImage";
 
 const UPCOMING_WINDOW_DAYS = 60;
 
@@ -11,15 +17,42 @@ interface UpcomingEventCardProps {
 
 function UpcomingEventCard({ item }: UpcomingEventCardProps) {
   const { event, sectionDef } = item;
-  const { day, month } = parseDateParts(event.date);
-  const weekday = weekdayAbbrev(event.date);
+  const {
+    parts: { day, month },
+    weekday,
+    time,
+    isoDate,
+  } = useEventDate(event);
   const openModal = useContext(EventModalContext);
   const showPopup = hasMeaningfulDescription(event);
   const { link: infoLink, label: infoLabel } = primaryEventLink(event, false);
+  const speakers = event.description ? getEventSpeakers(event.description) : [];
+  const teaser = speakers.length > 0
+    ? `Featuring ${formatSpeakerList(speakers)}`
+    : event.description
+      ? getDescriptionExcerpt(event.description)
+      : "";
 
   return (
-    <article className="flex flex-col gap-4 rounded-[16px] border border-ink-divider border-l-4 border-l-brand bg-page p-5 min-[640px]:flex-row min-[640px]:items-center min-[640px]:gap-6">
-      <time dateTime={event.date} className="flex shrink-0 flex-col items-center">
+    <article className="flex flex-col gap-4 rounded-[16px] border border-l-4 border-ink-divider border-l-brand bg-page p-5 min-[640px]:flex-row min-[640px]:items-center min-[640px]:gap-6">
+      {/* Mobile-only lead image: on the stacked mobile layout this reads as
+          a proper card banner. At the 640px row layout there's no good
+          place for it alongside a centered date badge and a single text
+          column, so it drops entirely rather than being squeezed in as a
+          small thumbnail. */}
+      <EventPreviewImage
+        event={event}
+        alt=""
+        className="aspect-video w-full rounded-[12px] bg-sand object-cover min-[640px]:hidden"
+      />
+
+      {/* Fixed width (not shrink-to-fit) at the row breakpoint: without it,
+          this box sizes itself to whichever child is widest — a 2-digit day
+          number is wider than the weekday text, a 1-digit day number is
+          narrower — so every card's box ends up a different width and the
+          centered content lands at a different x per card. A shared fixed
+          width makes every card's date column line up like a table column. */}
+      <time dateTime={isoDate} className="flex shrink-0 flex-col items-center min-[640px]:w-16">
         <span className="ts-overline text-ink-secondary">{weekday}</span>
         <span className="ts-heading leading-none text-brand">{day}</span>
         <span className="ts-overline text-ink-secondary">{month}</span>
@@ -30,7 +63,8 @@ function UpcomingEventCard({ item }: UpcomingEventCardProps) {
           {sectionDef.title}
         </span>
         <h3 className="ts-subheading truncate text-ink">{displayTitle(event)}</h3>
-        {event.time && <p className="ts-body-small text-ink-secondary">{event.time}</p>}
+        {time && <p className="ts-body-small text-ink-secondary">{time}</p>}
+        {teaser && <p className="ts-body-small mt-1 line-clamp-2 text-ink-secondary">{teaser}</p>}
       </div>
 
       <div className="flex shrink-0 flex-wrap items-center gap-4">

--- a/src/components/events/eventsShared.tsx
+++ b/src/components/events/eventsShared.tsx
@@ -1,4 +1,4 @@
-import { createContext, useCallback, useEffect, useRef, useState } from "react";
+import { createContext, useCallback, useContext, useEffect, useRef, useState } from "react";
 import type { EventItem } from "../../store/eventsClient";
 import { copyAnchorLink } from "../../utils/copyAnchorLink";
 
@@ -33,7 +33,7 @@ const MONTH_NAMES = [
 
 const WEEKDAY_NAMES = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 
-export function parseDateParts(dateStr: string): DateParts {
+function parseDateParts(dateStr: string): DateParts {
   const [year, month, day] = dateStr.split("-");
   return {
     day: parseInt(day, 10),
@@ -45,9 +45,68 @@ export function parseDateParts(dateStr: string): DateParts {
 
 // Weekday is derived separately (rather than folded into DateParts) since only
 // the Upcoming Events list needs it, for Kate's "how far out is this" ask.
-export function weekdayAbbrev(dateStr: string): string {
+function weekdayAbbrev(dateStr: string): string {
   const [year, month, day] = dateStr.split("-").map(Number);
   return WEEKDAY_NAMES[new Date(year, month - 1, day).getDay()];
+}
+
+// The ICS feed states times as wall clock in the *organizer's* zone (a TZID on
+// DTSTART, currently Asia/Jerusalem), so `event.date` and `event.time` are only
+// right for visitors who happen to live there — a 19:30 Jerusalem call rendered
+// "7:30 PM" for a visitor whose own clock read 18:30. `event.dateUtcIso` is the
+// actual instant, so derive everything shown from that instead and every
+// visitor reads the event in their own zone.
+//
+// The catch is SSR: the Cloudflare runtime's zone is UTC, so formatting during
+// a server render would bake in UTC and then mismatch on hydration. Islands
+// mounted `client:only` never server-render and can format on their first pass;
+// `client:load` ones have to wait for mount. VisitorZoneContext carries that
+// distinction — the default suits client:only, and a client:load island wraps
+// itself in a provider fed by useVisitorZoneReady().
+export const VisitorZoneContext = createContext(true);
+
+export function useVisitorZoneReady(): boolean {
+  const [ready, setReady] = useState(false);
+  useEffect(() => setReady(true), []);
+  return ready;
+}
+
+export interface EventDateDisplay {
+  parts: DateParts;
+  weekday: string;
+  time?: string;
+  isoDate: string;
+}
+
+function pad(value: number): string {
+  return String(value).padStart(2, "0");
+}
+
+export function useEventDate(event: EventItem): EventDateDisplay {
+  const zoneReady = useContext(VisitorZoneContext);
+
+  // All-day events carry no instant (dateUtcIso is null by design), so their
+  // organizer-supplied date is the only date there is — and it's zone-free.
+  const instant = zoneReady && event.dateUtcIso ? new Date(event.dateUtcIso) : null;
+  if (!instant || Number.isNaN(instant.getTime())) {
+    return {
+      parts: parseDateParts(event.date),
+      weekday: weekdayAbbrev(event.date),
+      time: event.time,
+      isoDate: event.date,
+    };
+  }
+
+  const day = instant.getDate();
+  const month = MONTH_NAMES[instant.getMonth()];
+  const year = String(instant.getFullYear());
+
+  return {
+    parts: { day, month, year, full: `${day} ${month} ${year}` },
+    weekday: WEEKDAY_NAMES[instant.getDay()],
+    time: instant.toLocaleString(undefined, { hour: "numeric", minute: "2-digit" }),
+    isoDate: `${year}-${pad(instant.getMonth() + 1)}-${pad(day)}`,
+  };
 }
 
 export function ArrowRight({ size = 16 }: { size?: number }) {

--- a/src/pages/events-new.astro
+++ b/src/pages/events-new.astro
@@ -10,15 +10,21 @@ const membershipLive = getEnv("MEMBERSHIP_LIVE", Astro.locals) === "true";
 
 const events: EventItem[] = await fetchEvents(Astro.locals).catch(() => []);
 
-const today = new Date();
-today.setHours(0, 0, 0, 0);
-const nextEvent = events.find((e) => new Date(e.date) >= today);
+// Pick and describe the next event by its instant, not by the organizer-zone
+// `date` string — that one is a day off for part of the world.
+// `fetchEvents` doesn't return the feed in date order, so pick the soonest
+// upcoming event explicitly — and compare instants rather than the
+// organizer-zone `date` string, which is a day off for part of the world.
+const now = Date.now();
+const nextEvent = events
+  .filter((e) => e.dateUtcIso && new Date(e.dateUtcIso).getTime() >= now)
+  .sort((a, b) => new Date(a.dateUtcIso!).getTime() - new Date(b.dateUtcIso!).getTime())[0];
 
 const eventSchema = nextEvent && {
   "@context": "https://schema.org",
   "@type": "Event",
   name: nextEvent.title,
-  startDate: nextEvent.date,
+  startDate: nextEvent.dateUtcIso,
   eventStatus: "https://schema.org/EventScheduled",
   image: [nextEvent.image || "https://techforpalestine.org/t4p-social-logo.png"],
   location: nextEvent.location

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,6 +2,7 @@
 import Layout from "../layouts/Layout.astro";
 import SignUpForm from "../structures/SignUpForm.astro";
 import CommunityCallBanner from "../components/CommunityCallBanner.astro";
+import UpcomingEventPopup from "../components/UpcomingEventPopup.tsx";
 import "../styles/base.css";
 ---
 
@@ -635,4 +636,5 @@ import "../styles/base.css";
       </div>
     </section>
   </main>
+  <UpcomingEventPopup client:only="react" />
 </Layout>

--- a/src/store/eventsClient.ts
+++ b/src/store/eventsClient.ts
@@ -5,14 +5,18 @@ import { reportError } from "../lib/report-error";
 export interface EventItem {
   id: string;
   title: string;
-  date: string; // "YYYY-MM-DD", local wall-clock date from the feed
+  // `date` and `time` are wall clock in the *organizer's* zone (the DTSTART
+  // TZID), not the visitor's — only safe to display for all-day events, which
+  // have no instant. Everything else should render from `dateUtcIso`; see
+  // useEventDate() in components/events/eventsShared.tsx.
+  date: string; // "YYYY-MM-DD" in the organizer's zone
   status: string;
   location: string;
   locationLink: string; // map link for in-person events, "" otherwise
   watchLink: string; // online join/stream link (e.g. a YouTube channel), "" otherwise
   image: string;
   link: string;
-  time?: string;
+  time?: string; // e.g. "7:30 PM" in the organizer's zone; absent for all-day events
   description?: string;
   registerLink?: string;
   recordingLink?: string;
@@ -174,7 +178,7 @@ function resolveLinks(properties: RawProperty[]): {
   return { registerLink: "", locationLink: "", watchLink: urlValue };
 }
 
-function formatLocalTime(timePart: string): string {
+function formatOrganizerLocalTime(timePart: string): string {
   const hour = Number(timePart.slice(0, 2));
   const minute = timePart.slice(2, 4);
   const period = hour >= 12 ? "PM" : "AM";
@@ -205,7 +209,7 @@ function parseVEvent(block: string[]): EventItem | null {
   if (!isAllDay) {
     const [rawDate, rawTime] = dtstart.value.replace("Z", "").split("T");
     date = `${rawDate.slice(0, 4)}-${rawDate.slice(4, 6)}-${rawDate.slice(6, 8)}`;
-    time = formatLocalTime(rawTime);
+    time = formatOrganizerLocalTime(rawTime);
   } else {
     date = `${dtstart.value.slice(0, 4)}-${dtstart.value.slice(4, 6)}-${dtstart.value.slice(6, 8)}`;
   }
@@ -295,7 +299,9 @@ function parseIcsCalendar(raw: string): EventItem[] {
     }
   }
 
-  return dedupeCommunityCallDuplicates(Array.from(byOccurrence.values()).map((entry) => entry.event));
+  return dedupeCommunityCallDuplicates(
+    Array.from(byOccurrence.values()).map((entry) => entry.event)
+  );
 }
 
 const COMMUNITY_CALL_TITLE_RE = /^(t4p\s+)?(monthly\s+)?community\s+(monthly\s+)?call/i;
@@ -345,7 +351,10 @@ export function hasMeaningfulDescription(event: EventItem): boolean {
   return (event.description?.trim().length ?? 0) >= MEANINGFUL_DESCRIPTION_MIN_LENGTH;
 }
 
-export function primaryEventLink(event: EventItem, isPast: boolean): { link: string; label: string } {
+export function primaryEventLink(
+  event: EventItem,
+  isPast: boolean
+): { link: string; label: string } {
   if (isPast) {
     // Registration is closed once an event is over — never offer it here,
     // even if the feed still has a registerLink set.

--- a/src/types/richText.ts
+++ b/src/types/richText.ts
@@ -31,4 +31,14 @@ export interface NotionRichText {
 export interface RichTextRendererProps {
   richText: RichTextSegment[] | NotionRichText;
   className?: string;
+  // Color classes default to the new design system's tokens (brand/ink),
+  // since that's this component's original caller (FAQSection, on
+  // /faq-new). Legacy callers (FAQAccordion on /faq, IdeasWithTabs on
+  // /ideas) pass their own page's colors instead — without this, Notion's
+  // "red" text and every link would render in the new brand palette
+  // regardless of which page's design language it's embedded in.
+  linkClassName?: string;
+  mutedTextClassName?: string; // Notion "gray" text color
+  accentTextClassName?: string; // Notion "red" text color
+  codeClassName?: string; // inline code background
 }

--- a/src/utils/eventDescription.tsx
+++ b/src/utils/eventDescription.tsx
@@ -102,6 +102,108 @@ function renderLinksAndUrls(text: string, keyPrefix: string): React.ReactNode[] 
     });
 }
 
+// The caller clamps this to 2 lines with CSS (`line-clamp-2`), which doesn't
+// respect word boundaries the way this truncation does — if the text is
+// longer than what actually fits, the browser re-truncates it a second time
+// mid-word. Kept short enough to fit within 2 lines even on a narrow mobile
+// card so line-clamp only ever acts as a safety net, not the real truncator.
+const EXCERPT_MAX_LENGTH = 85;
+
+// Strips this feed's markdown subset down to plain text: emphasis markers,
+// link syntax (keeping the label), and line breaks collapsed to spaces.
+function toPlainText(text: string): string {
+  return text
+    .replace(LINK_OR_URL_PATTERN, (match) => {
+      const linkMatch = match.match(LINK_RE);
+      return linkMatch ? linkMatch[1] : match;
+    })
+    .replace(/\*\*([^*]+)\*\*/g, "$1")
+    .replace(/\*([^*]+)\*/g, "$1")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+// A short plain-text teaser for the upcoming-events list, so a visitor gets a
+// sense of what an event is about without opening its "More info" modal.
+// Pulled from the first real paragraph — headings ("## Agenda"), rules, and
+// lists don't make a readable teaser, so a description that's only those
+// (rare) yields no excerpt rather than a confusing fragment.
+export function getDescriptionExcerpt(description: string): string {
+  const firstParagraph = parseEventDescription(description).find(
+    (block) => block.type === "paragraph"
+  );
+  if (!firstParagraph) return "";
+
+  const plain = toPlainText(firstParagraph.text);
+  if (plain.length <= EXCERPT_MAX_LENGTH) return plain;
+
+  const truncated = plain.slice(0, EXCERPT_MAX_LENGTH);
+  const lastSpace = truncated.lastIndexOf(" ");
+  return `${truncated.slice(0, lastSpace > 0 ? lastSpace : EXCERPT_MAX_LENGTH)}…`;
+}
+
+// Matches a section label like "**OUR SPEAKERS**" or "**Panelists**" that
+// introduces a speaker list — organizers write this fairly consistently, but
+// the wording varies a little.
+const SPEAKER_SECTION_LABEL_RE = /^\*\*(?:OUR\s+)?(?:SPEAKERS?|PANELISTS?|GUESTS?)\*\*$/i;
+// Matches a speaker entry's name line, e.g. "**MOATH HAMZEH - Digital Creator
+// & Activist**" — the bio (if any) follows on the next line of the same block.
+const SPEAKER_NAME_LINE_RE = /^\*\*([^*]+?)\s*[-–—]\s*[^*]*\*\*$/;
+const MAX_LISTED_SPEAKERS = 3;
+
+// Organizers write speaker names in all caps for emphasis; that reads as
+// shouting inline, so re-case anything fully uppercase to Title Case while
+// leaving already mixed-case names untouched.
+function toDisplayName(raw: string): string {
+  const trimmed = raw.trim();
+  if (trimmed !== trimmed.toUpperCase()) return trimmed;
+  return trimmed.toLowerCase().replace(/(^|[\s'-])([a-z])/g, (_match, sep, ch) => sep + ch.toUpperCase());
+}
+
+// Extracts speaker/panelist names from a "**OUR SPEAKERS**" section, if the
+// description has one — a heuristic on top of this feed's loose convention,
+// not a guaranteed field. Returns [] for the majority of events that don't
+// use this format, so callers should fall back to a plain excerpt.
+export function getEventSpeakers(description: string): string[] {
+  const blocks = parseEventDescription(description);
+  // The label often shares a block with a preceding "---" rule (joined by a
+  // single newline rather than the blank line that would split them into
+  // separate blocks), so check each line of a paragraph block rather than
+  // requiring the whole block to be just the label.
+  const sectionStart = blocks.findIndex(
+    (block) =>
+      block.type === "paragraph" &&
+      block.text.split("\n").some((line) => SPEAKER_SECTION_LABEL_RE.test(line.trim()))
+  );
+  if (sectionStart === -1) return [];
+
+  const speakers: string[] = [];
+  for (let i = sectionStart + 1; i < blocks.length; i++) {
+    const block = blocks[i];
+    if (block.type !== "paragraph") break;
+
+    const nameLine = block.text.split("\n")[0].trim();
+    const match = nameLine.match(SPEAKER_NAME_LINE_RE);
+    if (!match) break;
+
+    speakers.push(toDisplayName(match[1]));
+  }
+
+  return speakers;
+}
+
+// "Mo Hamzeh, Taysir Matlob and 2 more" / "Mo Hamzeh and Taysir Matlob" /
+// "Mo Hamzeh" — a readable list capped so a long panel doesn't run on.
+export function formatSpeakerList(names: string[]): string {
+  if (names.length === 0) return "";
+  if (names.length === 1) return names[0];
+  if (names.length <= MAX_LISTED_SPEAKERS) {
+    return `${names.slice(0, -1).join(", ")} and ${names[names.length - 1]}`;
+  }
+  const shown = names.slice(0, MAX_LISTED_SPEAKERS).join(", ");
+  return `${shown} and ${names.length - MAX_LISTED_SPEAKERS} more`;
+}
+
 // Renders **bold**/*italic* spans (a link can appear nested inside either,
 // e.g. "*Summary taken from ... [Just World Books](url)*"), auto-links bare
 // URLs and [label](url) links, and turns single newlines into <br/>. No raw

--- a/src/utils/eventSections.ts
+++ b/src/utils/eventSections.ts
@@ -1,8 +1,6 @@
 import type { EventItem } from "../store/eventsClient";
 import { youtubeThumbnailSources } from "./youtubeThumbnail";
 
-const COMMUNITY_CALLS_SECTION_KEY = "community-calls";
-
 export interface EventSectionDef {
   key: string;
   title: string;
@@ -94,20 +92,22 @@ export interface PreviewImageSources {
   fallback: string | null;
 }
 
-// Community Calls are recorded to the same generic "T4P Monthly Community
-// Call" banner every month, so the banner image carries no information about
-// which call it actually is — the YouTube thumbnail (when a recording
-// exists) is far more identifiable at a glance. Scoped to Community Calls
-// only: other categories' banners are per-event and already meaningful.
+// A real recording/stream thumbnail is generally more identifiable at a
+// glance than a static event banner (most visibly true for Community Calls,
+// which reuse the same generic "T4P Monthly Community Call" graphic every
+// month, but it applies to any event) — so prefer it whenever the recording
+// or watch link resolves to a YouTube video, for every category, not just
+// Community Calls. Falls back to the feed's own image when neither link is
+// a YouTube URL (e.g. a Zoom link, or no recording yet).
 //
 // `fallback` is only set when `primary` is a YouTube thumbnail: the HD
 // maxresdefault.jpg isn't guaranteed to exist, so callers (EventPreviewImage)
 // need a second URL to drop down to.
 export function previewImageSources(event: EventItem): PreviewImageSources {
-  if (event.recordingLink && sectionForEvent(event)?.key === COMMUNITY_CALLS_SECTION_KEY) {
-    const sources = youtubeThumbnailSources(event.recordingLink);
-    if (sources) return sources;
-  }
+  const sources =
+    (event.recordingLink && youtubeThumbnailSources(event.recordingLink)) ||
+    (event.watchLink && youtubeThumbnailSources(event.watchLink));
+  if (sources) return sources;
   return { primary: event.image, fallback: null };
 }
 


### PR DESCRIPTION
## Summary
- Event times/dates now show in the visitor's own timezone instead of the organizer's (was showing Jerusalem time to everyone)
- Fixed duplicate date and cropped image in the event detail modal (both pages)
- Rebuilt legacy `/events` off MUI onto Tailwind, matching `/events-new`'s type scale and a11y baseline (focus rings, 44px touch targets)
- Upcoming cards now show a thumbnail + description excerpt, with speaker-name extraction ("Featuring X, Y") when available
- YouTube thumbnail preview now applies to any event with a recording/stream link, not just Community Calls
- Fixed date-badge misalignment across cards (fixed width instead of shrink-to-fit)
- Fixed `RichTextRenderer` leaking new-design colors (`text-brand`, `text-ink-secondary`) into legacy `/faq` and `/ideas`

## Test plan
- [ ] `/events` and `/events-new`: confirm event times match your local timezone, not the organizer's
- [ ] Open an event's "More info" modal on both pages: date shown once, image not cropped
- [ ] Upcoming list: thumbnail + excerpt render, long titles/excerpts don't break layout, date badges align down the list (mix of 1- and 2-digit days)
- [ ] `/faq` and `/ideas`: links and colored text use legacy colors, not the new brand palette; `/faq-new` and `/ideas-new` unchanged
- [ ] `pnpm build` / `astro check` pass