### PR TITLE
Sharpen event popup: bigger CTA, urgency chip, fix mobile All-events link

### DIFF
--- a/src/components/UpcomingEventPopup.tsx
+++ b/src/components/UpcomingEventPopup.tsx
@@ -16,19 +16,30 @@ function track(name: string, event: EventItem) {
   window.plausible(name, { props: { event_id: event.id, event_title: event.title } });
 }
 
-/** "Today" / "Tomorrow" / "In N days" for events happening soon, or null once
- * an event is far enough out that urgency framing would be misleading. */
-function relativeDayLabel(isoDate: string): string | null {
+function daysUntil(isoDate: string): number {
   const [year, month, day] = isoDate.split("-").map(Number);
   const eventDay = new Date(year, month - 1, day);
   const today = new Date();
   const todayMidnight = new Date(today.getFullYear(), today.getMonth(), today.getDate());
-  const diffDays = Math.round((eventDay.getTime() - todayMidnight.getTime()) / 86_400_000);
+  return Math.round((eventDay.getTime() - todayMidnight.getTime()) / 86_400_000);
+}
 
+/** "Today" / "Tomorrow" / "In N days" for events happening soon, or null once
+ * an event is far enough out that urgency framing would be misleading. */
+function relativeDayLabel(diffDays: number): string | null {
   if (diffDays === 0) return "Today";
   if (diffDays === 1) return "Tomorrow";
   if (diffDays > 1 && diffDays <= URGENCY_WINDOW_DAYS) return `In ${diffDays} days`;
   return null;
+}
+
+/** A plain scheduling question as the CTA lead-in — works the same for a
+ * roundtable, a book club, or a conference, since it doesn't try to
+ * characterize the event's content (the title above it already does that). */
+function freeDayQuestion(diffDays: number, weekday: string): string {
+  if (diffDays === 0) return "Free today?";
+  if (diffDays === 1) return "Free tomorrow?";
+  return `Free this ${weekday}?`;
 }
 
 function PopupCard({
@@ -52,7 +63,9 @@ function PopupCard({
   // itself, since that label is shared with the full /events page and its
   // cards, where the more neutral wording still fits.
   const ctaLabel = label === "Register" ? "Save my spot" : label;
-  const urgency = relativeDayLabel(isoDate);
+  const diffDays = daysUntil(isoDate);
+  const urgency = relativeDayLabel(diffDays);
+  const question = freeDayQuestion(diffDays, weekday);
   const title = displayTitle(event);
 
   return (
@@ -107,6 +120,7 @@ function PopupCard({
             title
           )}
         </h3>
+        <p className="mt-1 text-sm text-gray-700">{question}</p>
         <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1.5">
           {link && (
             <a

--- a/src/components/UpcomingEventPopup.tsx
+++ b/src/components/UpcomingEventPopup.tsx
@@ -7,10 +7,28 @@ import { ArrowRight, CloseIcon, useEventDate } from "./events/eventsShared";
 const SHOW_DELAY_MS = 2000;
 const UPCOMING_WINDOW_DAYS = 60;
 const DISMISSED_KEY = "dismissed_event_popup_id";
+/** Beyond this many days out, a relative label ("In 6 days") reads as noise
+ * rather than urgency, so the popup falls back to the plain weekday/date. */
+const URGENCY_WINDOW_DAYS = 6;
 
 function track(name: string, event: EventItem) {
   if (typeof window.plausible === "undefined") return;
   window.plausible(name, { props: { event_id: event.id, event_title: event.title } });
+}
+
+/** "Today" / "Tomorrow" / "In N days" for events happening soon, or null once
+ * an event is far enough out that urgency framing would be misleading. */
+function relativeDayLabel(isoDate: string): string | null {
+  const [year, month, day] = isoDate.split("-").map(Number);
+  const eventDay = new Date(year, month - 1, day);
+  const today = new Date();
+  const todayMidnight = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+  const diffDays = Math.round((eventDay.getTime() - todayMidnight.getTime()) / 86_400_000);
+
+  if (diffDays === 0) return "Today";
+  if (diffDays === 1) return "Tomorrow";
+  if (diffDays > 1 && diffDays <= URGENCY_WINDOW_DAYS) return `In ${diffDays} days`;
+  return null;
 }
 
 function PopupCard({
@@ -26,8 +44,15 @@ function PopupCard({
     parts: { day, month },
     weekday,
     time,
+    isoDate,
   } = useEventDate(event);
   const { link, label } = primaryEventLink(event, false);
+  // "Register" reads as a form to fill out; "Save my spot" reads as claiming
+  // something scarce. Overridden here rather than in primaryEventLink()
+  // itself, since that label is shared with the full /events page and its
+  // cards, where the more neutral wording still fits.
+  const ctaLabel = label === "Register" ? "Save my spot" : label;
+  const urgency = relativeDayLabel(isoDate);
   const title = displayTitle(event);
 
   return (
@@ -53,28 +78,52 @@ function PopupCard({
       </div>
 
       <div className="min-w-0 flex-1 sm:flex-none sm:p-4">
+        {urgency && (
+          <span className="mb-1 inline-flex items-center gap-1 rounded-full bg-[#EA4335]/10 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide text-[#EA4335]">
+            <span className="h-1.5 w-1.5 rounded-full bg-[#EA4335]" />
+            {urgency}
+          </span>
+        )}
         <p className="truncate text-xs font-medium uppercase tracking-wide text-gray-500">
           {weekday}, {month} {day}
           {time ? ` · ${time}` : ""}
         </p>
-        <h3 className="truncate font-bold text-gray-900">{title}</h3>
-        <div className="mt-2 flex items-center gap-3">
+        {/* The title links to the same registration page as the CTA below —
+            that page has the full event details, so it doubles as a "more
+            info" surface for anyone who reads the headline before noticing
+            the button. */}
+        <h3 className="truncate font-bold text-gray-900">
+          {link ? (
+            <a
+              href={link}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() => track("Event Popup Title Click", event)}
+              className="hover:underline"
+            >
+              {title}
+            </a>
+          ) : (
+            title
+          )}
+        </h3>
+        <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1.5">
           {link && (
             <a
               href={link}
               target="_blank"
               rel="noopener noreferrer"
               onClick={() => track("Event Popup Register Click", event)}
-              className="inline-flex items-center gap-1 rounded-full bg-[#EA4335] px-3 py-1.5 text-sm font-medium text-white transition-colors duration-150 hover:bg-[#C5341F] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#EA4335]"
+              className="inline-flex items-center gap-1.5 rounded-full bg-[#EA4335] px-4 py-2 text-sm font-semibold text-white shadow-sm transition-all duration-150 hover:bg-[#C5341F] hover:shadow focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#EA4335]"
             >
-              {label}
-              <ArrowRight size={14} />
+              {ctaLabel}
+              <ArrowRight size={15} />
             </a>
           )}
           <a
             href="/events"
             onClick={() => track("Event Popup All Events Click", event)}
-            className="hidden text-sm font-medium text-gray-600 underline-offset-4 hover:text-gray-900 hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#EA4335] sm:inline"
+            className="text-sm font-medium text-gray-600 underline-offset-4 hover:text-gray-900 hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#EA4335]"
           >
             All events
           </a>


### PR DESCRIPTION
## Summary
Based on the first ~1.5 days of Plausible data for the new upcoming-event popup (`Event Popup Shown`: 140, `Event Popup Register Click`: 3, `Event Popup Dismissed`: 17 and falling) — dismissal wasn't the problem, low click-through was. This makes the popup easier to act on at first glance:

- Fixes the "All events" link being hard-hidden below the `sm` breakpoint — invisible to ~34% of traffic (mobile). It now wraps onto its own line instead.
- Swaps the generic CTA label "Register" for **"Save my spot"** in the popup only (the shared `primaryEventLink()` used by `/events` and event cards is untouched).
- Adds a small urgency chip ("Today" / "Tomorrow" / "In N days") for events within a week; falls back to the plain date further out.
- Makes the event title a link to the same registration page — it has full event details, so it doubles as a "more info" surface for people who read the headline before noticing the button.
- Gives the CTA button more visual weight (bigger padding, bolder text, hover shadow).

Did not make the popup non-dismissible — dismiss rate was already low (~12%, falling) and forcing it would risk annoying the ~85% of viewers who neither click nor dismiss, without addressing the actual bottleneck (CTA click-through).

## Test plan
- [ ] Visit the homepage with a mock/real upcoming event within 6 days and confirm the "Today"/"Tomorrow"/"In N days" chip renders correctly.
- [ ] Visit on mobile width and confirm "All events" is now visible (wraps below the CTA button instead of being hidden).
- [ ] Click the event title and confirm it opens the registration link (same destination as the CTA button).
- [ ] Confirm dismiss (✕) still works and is remembered per event id.
- [ ] Check Plausible after a few days for `Event Popup Register Click` and `Event Popup Title Click` trend vs. the pre-change baseline.