### PR TITLE
fix(events): prefer MM flyer over YouTube thumbnail

### DIFF
--- a/src/store/eventsClient.ts
+++ b/src/store/eventsClient.ts
@@ -135,12 +135,14 @@ function stripInlineRegistrationLines(description: string): string {
   return kept.join("\n");
 }
 
+export const DEFAULT_EVENT_IMAGE = "/images/default.jpg";
+
 function extractImage(properties: RawProperty[]): string {
   const image = properties.find((p) => p.name === "IMAGE");
   if (image?.value) return image.value;
   const attach = properties.find((p) => p.name === "ATTACH");
   if (attach?.value) return attach.value;
-  return "/images/default.jpg";
+  return DEFAULT_EVENT_IMAGE;
 }
 
 function matchesHost(url: string, hosts: string[]): boolean {

--- a/src/utils/eventSections.ts
+++ b/src/utils/eventSections.ts
@@ -1,4 +1,4 @@
-import type { EventItem } from "../store/eventsClient";
+import { DEFAULT_EVENT_IMAGE, type EventItem } from "../store/eventsClient";
 import { youtubeThumbnailSources } from "./youtubeThumbnail";
 
 export interface EventSectionDef {
@@ -92,23 +92,22 @@ export interface PreviewImageSources {
   fallback: string | null;
 }
 
-// A real recording/stream thumbnail is generally more identifiable at a
-// glance than a static event banner (most visibly true for Community Calls,
-// which reuse the same generic "T4P Monthly Community Call" graphic every
-// month, but it applies to any event) — so prefer it whenever the recording
-// or watch link resolves to a YouTube video, for every category, not just
-// Community Calls. Falls back to the feed's own image when neither link is
-// a YouTube URL (e.g. a Zoom link, or no recording yet).
+// Prefer the organizer's own flyer/banner set in Mattermost when there is
+// one — it's the event's intended presentation. Only fall back to a YouTube
+// recording/stream thumbnail when no flyer was set (the feed then defaults
+// `image` to "/images/default.jpg").
 //
 // `fallback` is only set when `primary` is a YouTube thumbnail: the HD
 // maxresdefault.jpg isn't guaranteed to exist, so callers (EventPreviewImage)
 // need a second URL to drop down to.
 export function previewImageSources(event: EventItem): PreviewImageSources {
+  if (event.image !== DEFAULT_EVENT_IMAGE) {
+    return { primary: event.image, fallback: null };
+  }
   const sources =
     (event.recordingLink && youtubeThumbnailSources(event.recordingLink)) ||
     (event.watchLink && youtubeThumbnailSources(event.watchLink));
-  if (sources) return sources;
-  return { primary: event.image, fallback: null };
+  return sources || { primary: event.image, fallback: null };
 }
 
 export interface UpcomingEvent {


### PR DESCRIPTION
## Summary
- Event preview images now use the flyer/banner set in Mattermost (the ICS `IMAGE`/`ATTACH` field) whenever one is set, on both `/events` and `/events-new`.
- The YouTube recording/stream thumbnail is now only used as a fallback when no flyer was set (i.e. `image` is still the `/images/default.jpg` default).
- Shared logic lives in `previewImageSources()` (`src/utils/eventSections.ts`), consumed by `EventPreviewImage`, so both pages get the fix automatically.

## Test plan
- [x] Confirm an event with a flyer set in Mattermost shows the flyer on `/events` and `/events-new`, even when it also has a YouTube recording link.
- [x] Confirm an event with no flyer (default image) and a YouTube recording/watch link still shows the YouTube thumbnail.
- [x] `pnpm check` passes.