### PR TITLE
fix(events): clear ?event= param when its modal closes

### DIFF
--- a/src/components/Events.tsx
+++ b/src/components/Events.tsx
@@ -9,7 +9,7 @@ import {
   type EventSection,
   type UpcomingEvent,
 } from "../utils/eventSections";
-import { copyAnchorLink, copyEventLink } from "../utils/copyAnchorLink";
+import { copyAnchorLink, copyEventLink, clearEventLinkParam } from "../utils/copyAnchorLink";
 import {
   formatSpeakerList,
   getDescriptionExcerpt,
@@ -735,7 +735,13 @@ export default function Events({
           </div>
         )}
       </div>
-      <EventDetailsDialog selected={selectedEvent} onClose={() => setSelectedEvent(null)} />
+      <EventDetailsDialog
+        selected={selectedEvent}
+        onClose={() => {
+          setSelectedEvent(null);
+          clearEventLinkParam();
+        }}
+      />
     </EventModalContext.Provider>
   );
 }

--- a/src/components/events/EventsNew.tsx
+++ b/src/components/events/EventsNew.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import type { EventItem } from "../../store/eventsClient";
 import { groupIntoSections, isEventPast } from "../../utils/eventSections";
+import { clearEventLinkParam } from "../../utils/copyAnchorLink";
 import {
   EventModalContext,
   useVisitorZoneReady,
@@ -119,7 +120,13 @@ export default function EventsNew({ initialEvents = [] }: EventsNewProps) {
           )}
         </div>
         {selectedEvent && (
-          <EventModal selected={selectedEvent} onClose={() => setSelectedEvent(null)} />
+          <EventModal
+            selected={selectedEvent}
+            onClose={() => {
+              setSelectedEvent(null);
+              clearEventLinkParam();
+            }}
+          />
         )}
       </EventModalContext.Provider>
     </VisitorZoneContext.Provider>

--- a/src/utils/copyAnchorLink.ts
+++ b/src/utils/copyAnchorLink.ts
@@ -30,3 +30,13 @@ export async function copyEventLink(id: string): Promise<boolean> {
     return false;
   }
 }
+
+// Strips a `?event=` param left by copyEventLink (or a pasted deep link) once
+// its modal is closed, so the URL doesn't keep pointing at an event that's no
+// longer on screen.
+export function clearEventLinkParam(): void {
+  const url = new URL(window.location.href);
+  if (!url.searchParams.has("event")) return;
+  url.searchParams.delete("event");
+  history.replaceState(null, "", `${url.pathname}${url.search}${url.hash}`);
+}


### PR DESCRIPTION
## Summary
- The `?event=<id>` param added by the event modal's "copy link" button (#534) was staying in the URL after the modal was closed, even though it no longer pointed at anything visible on the page.
- Adds `clearEventLinkParam()` (`src/utils/copyAnchorLink.ts`), called from both `/events` and `/events-new`'s modal close handlers, which strips the `event` param via `history.replaceState` while preserving any other query params/hash.

## Test plan
- [ ] Visit a copied event link (`.../events?event=<id>`), confirm the modal auto-opens.
- [ ] Close it (X button, Escape, or clicking the backdrop) and confirm the URL reverts to the plain page path (no `?event=`).
- [ ] Repeat on `/events-new`.
- [ ] `pnpm check` passes.