### PR TITLE
fix(events): use copy icon and full confirmation text on event link copy

### DIFF
--- a/src/components/Events.tsx
+++ b/src/components/Events.tsx
@@ -217,7 +217,7 @@ function EventDetailsDialogBody({
           {copied && (
             <span
               role="status"
-              className={`absolute -top-9 right-0 whitespace-nowrap rounded-full bg-gray-900 px-3 py-1.5 text-white ${TS_CAPTION_SIZE}`}
+              className={`absolute right-0 top-full mt-2 whitespace-nowrap rounded-full bg-gray-900 px-3 py-1.5 text-white ${TS_CAPTION_SIZE}`}
             >
               Event URL copied to clipboard successfully
             </span>

--- a/src/components/Events.tsx
+++ b/src/components/Events.tsx
@@ -22,8 +22,8 @@ import {
   ArrowRight,
   ChevronDown,
   CloseIcon,
+  CopyIcon,
   EventModalContext,
-  ShareIcon,
   useCarouselScroll,
   useEventDate,
   type SelectedEvent,
@@ -31,6 +31,7 @@ import {
 
 const UPCOMING_WINDOW_DAYS = 60;
 const COPIED_FEEDBACK_MS = 1500;
+const EVENT_COPY_FEEDBACK_MS = 2500;
 
 // Font sizes only (not family/weight/color) matched to /events-new's type
 // scale in src/styles/design-system.css, stepped at the same 390/810/1200
@@ -179,7 +180,7 @@ function EventDetailsDialogBody({
     const ok = await copyEventLink(event.id);
     if (!ok) return;
     setCopied(true);
-    window.setTimeout(() => setCopied(false), COPIED_FEEDBACK_MS);
+    window.setTimeout(() => setCopied(false), EVENT_COPY_FEEDBACK_MS);
   };
 
   // MUI Dialog is kept for its focus trap, escape handling, and scroll lock;
@@ -211,14 +212,14 @@ function EventDetailsDialogBody({
             aria-label="Copy link to this event"
             className="inline-flex h-11 w-11 items-center justify-center rounded-full bg-white text-gray-700 shadow-sm transition-colors duration-150 hover:bg-[#EA4335] hover:text-white focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#EA4335]"
           >
-            <ShareIcon />
+            <CopyIcon />
           </button>
           {copied && (
             <span
               role="status"
-              className={`absolute -top-9 left-1/2 -translate-x-1/2 whitespace-nowrap rounded-full bg-gray-900 px-3 py-1 text-white ${TS_CAPTION_SIZE}`}
+              className={`absolute -top-9 right-0 whitespace-nowrap rounded-full bg-gray-900 px-3 py-1.5 text-white ${TS_CAPTION_SIZE}`}
             >
-              Copied!
+              Event URL copied to clipboard successfully
             </span>
           )}
         </span>

--- a/src/components/events/EventModal.tsx
+++ b/src/components/events/EventModal.tsx
@@ -4,10 +4,10 @@ import { displayTitle } from "../../utils/eventSections";
 import { parseEventDescription, renderInlineText } from "../../utils/eventDescription";
 import { useBodyScrollLock } from "../../utils/useBodyScrollLock";
 import { copyEventLink } from "../../utils/copyAnchorLink";
-import { ArrowRight, CloseIcon, ShareIcon, useEventDate, type SelectedEvent } from "./eventsShared";
+import { ArrowRight, CloseIcon, CopyIcon, useEventDate, type SelectedEvent } from "./eventsShared";
 import { EventPreviewImage } from "./EventPreviewImage";
 
-const COPIED_FEEDBACK_MS = 1500;
+const COPIED_FEEDBACK_MS = 2500;
 
 function EventDescription({ text }: { text: string }) {
   const blocks = parseEventDescription(text);
@@ -109,14 +109,14 @@ export function EventModal({ selected, onClose }: EventModalProps) {
                 aria-label="Copy link to this event"
                 className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-page text-ink transition-colors duration-150 hover:bg-brand hover:text-page focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand"
               >
-                <ShareIcon />
+                <CopyIcon />
               </button>
               {copied && (
                 <span
                   role="status"
-                  className="ts-caption absolute -top-8 left-1/2 -translate-x-1/2 whitespace-nowrap rounded-pill bg-ink px-2.5 py-1 text-page"
+                  className="ts-caption absolute -top-8 right-0 whitespace-nowrap rounded-pill bg-ink px-3 py-1.5 text-page"
                 >
-                  Copied!
+                  Event URL copied to clipboard successfully
                 </span>
               )}
             </span>

--- a/src/components/events/EventModal.tsx
+++ b/src/components/events/EventModal.tsx
@@ -114,7 +114,7 @@ export function EventModal({ selected, onClose }: EventModalProps) {
               {copied && (
                 <span
                   role="status"
-                  className="ts-caption absolute -top-8 right-0 whitespace-nowrap rounded-pill bg-ink px-3 py-1.5 text-page"
+                  className="ts-caption absolute right-0 top-full mt-2 whitespace-nowrap rounded-pill bg-ink px-3 py-1.5 text-page"
                 >
                   Event URL copied to clipboard successfully
                 </span>

--- a/src/components/events/eventsShared.tsx
+++ b/src/components/events/eventsShared.tsx
@@ -147,7 +147,7 @@ export function ChevronDown({ size = 18, expanded }: { size?: number; expanded: 
   );
 }
 
-export function ShareIcon({ size = 18 }: { size?: number }) {
+export function CopyIcon({ size = 18 }: { size?: number }) {
   return (
     <svg
       width={size}
@@ -160,11 +160,8 @@ export function ShareIcon({ size = 18 }: { size?: number }) {
       strokeLinejoin="round"
       aria-hidden="true"
     >
-      <circle cx="18" cy="5" r="3" />
-      <circle cx="6" cy="12" r="3" />
-      <circle cx="18" cy="19" r="3" />
-      <line x1="8.59" y1="13.51" x2="15.42" y2="17.49" />
-      <line x1="15.41" y1="6.51" x2="8.59" y2="10.49" />
+      <rect x="9" y="9" width="12" height="12" rx="2" />
+      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
     </svg>
   );
 }


### PR DESCRIPTION
## Summary
- Replaces the "share" icon with a "copy" icon on the copy-link button in the event modal, on both `/events` and `/events-new`
- Replaces the small "Copied!" tooltip with "Event URL copied to clipboard successfully" (extended the display duration to 2.5s so the longer message is readable)
- Removed `ShareIcon` (now unused) and added `CopyIcon` in `eventsShared.tsx`
- Left the separate "#" category-anchor copy button and its "Copied!" tooltip untouched — this only applies to the event modal's copy-link button

## Test plan
- [x] `pnpm check` passes
- [x] Open an event modal on `/events`, click the copy-link button, confirm the copy icon shows and the new confirmation message appears/clears correctly
- [x] Repeat on `/events-new`
- [x] Confirm the "#" section-copy tooltip on both pages still says "Copied!" (unchanged)