### PR TITLE
feat(volunteer): list open roles from the Hub in place of the Notion button

### DIFF
--- a/src/components/volunteer/OpenRoleCard.tsx
+++ b/src/components/volunteer/OpenRoleCard.tsx
@@ -1,0 +1,130 @@
+import React, { useId, useState } from "react";
+import { getApplyTarget, type OpenRole } from "./openRoleData";
+import type { SkinTokens } from "./openRoleSkins";
+
+/** Descriptions shorter than this read fine in full, so they get no toggle. */
+const CLAMP_THRESHOLD = 260;
+
+function ClockIcon() {
+  return (
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="9" />
+      <path d="M12 7v5l3 2" />
+    </svg>
+  );
+}
+
+function Chevron({ expanded }: { expanded: boolean }) {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      className={`transition-transform duration-150 ${expanded ? "rotate-180" : ""}`}
+      aria-hidden="true"
+    >
+      <path d="M6 9l6 6 6-6" />
+    </svg>
+  );
+}
+
+interface OpenRoleCardProps {
+  role: OpenRole;
+  tokens: SkinTokens;
+}
+
+export default function OpenRoleCard({ role, tokens }: OpenRoleCardProps) {
+  const [expanded, setExpanded] = useState(false);
+  const descriptionId = useId();
+  const apply = getApplyTarget(role);
+  const isTeamRole = role.type === "team";
+  const canCollapse = role.description.length > CLAMP_THRESHOLD;
+  const isCollapsed = canCollapse && !expanded;
+
+  return (
+    <article className={tokens.card}>
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0">
+          {(role.orgName || isTeamRole) && (
+            <p className="mb-1.5 flex flex-wrap items-center gap-2">
+              {role.orgName && <span className={tokens.org}>{role.orgName}</span>}
+              {isTeamRole && <span className={tokens.orgMarker}>T4P team</span>}
+            </p>
+          )}
+          <h3 className={`${tokens.title} break-words`}>{role.title}</h3>
+        </div>
+
+        <a
+          href={apply.href}
+          className={`${isTeamRole ? tokens.applyTeam : tokens.applyProject} ${tokens.focus} shrink-0`}
+        >
+          {apply.label}
+          <span className="sr-only"> as {role.title}</span>
+        </a>
+      </div>
+
+      {(role.skillCategories.length > 0 || role.timeCommitment) && (
+        <ul className="mt-4 flex flex-wrap gap-2">
+          {role.skillCategories.map((skill) => (
+            <li key={skill} className={tokens.pill}>
+              {skill}
+            </li>
+          ))}
+          {role.timeCommitment && (
+            <li className={tokens.pill}>
+              <ClockIcon />
+              {role.timeCommitment}
+            </li>
+          )}
+        </ul>
+      )}
+
+      {role.description && (
+        <>
+          <p
+            id={descriptionId}
+            className={`mt-4 max-w-[75ch] ${tokens.body} ${
+              isCollapsed ? "line-clamp-3" : "whitespace-pre-line"
+            }`}
+          >
+            {/* Several descriptions open with a short heading line, which would
+                spend the three-line clamp on almost no content. Flattening the
+                whitespace while collapsed gives three full lines of preview. */}
+            {isCollapsed ? role.description.replace(/\s+/g, " ") : role.description}
+          </p>
+
+          {canCollapse && (
+            <button
+              type="button"
+              onClick={() => setExpanded((value) => !value)}
+              aria-expanded={expanded}
+              aria-controls={descriptionId}
+              className={`mt-1 ${tokens.disclosure} ${tokens.focus}`}
+            >
+              {expanded ? "Show less" : "Read the full role"}
+              <Chevron expanded={expanded} />
+            </button>
+          )}
+        </>
+      )}
+
+      {expanded && role.areasOfInterest.length > 0 && (
+        <p className="mt-3">
+          <span className={tokens.detailLabel}>Areas of interest: </span>
+          <span className={tokens.body}>{role.areasOfInterest.join(", ")}</span>
+        </p>
+      )}
+    </article>
+  );
+}

--- a/src/components/volunteer/OpenRoles.tsx
+++ b/src/components/volunteer/OpenRoles.tsx
@@ -1,0 +1,174 @@
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  getSkillFilters,
+  normalizeOpenRoles,
+  VOLUNTEER_FORM_URL,
+  type OpenRole,
+} from "./openRoleData";
+import { getSkinTokens, type OpenRolesSkin } from "./openRoleSkins";
+import OpenRoleCard from "./OpenRoleCard";
+
+type LoadState = "loading" | "ready" | "error";
+
+interface OpenRolesProps {
+  skin?: OpenRolesSkin;
+}
+
+const ALL_SKILLS = "all";
+
+/**
+ * The Hub reports ~15 skill categories, most with a single role. Showing all of
+ * them at once buries the list under filters, so the long tail sits behind a
+ * toggle — the same treatment TagFilter gives project tags.
+ */
+const MAX_VISIBLE_FILTERS = 8;
+
+export default function OpenRoles({ skin = "classic" }: OpenRolesProps) {
+  const tokens = getSkinTokens(skin);
+  const [roles, setRoles] = useState<OpenRole[]>([]);
+  const [state, setState] = useState<LoadState>("loading");
+  const [activeSkill, setActiveSkill] = useState<string>(ALL_SKILLS);
+  const [showAllFilters, setShowAllFilters] = useState(false);
+
+  const load = useCallback(async () => {
+    setState("loading");
+    try {
+      const response = await fetch("/api/open-roles", { cache: "no-cache" });
+      if (!response.ok) throw new Error(`Request failed: ${response.status}`);
+      const payload = await response.json();
+      setRoles(normalizeOpenRoles(payload.roles));
+      setState("ready");
+    } catch {
+      setState("error");
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const skillFilters = useMemo(() => getSkillFilters(roles), [roles]);
+
+  const visibleRoles = useMemo(
+    () =>
+      activeSkill === ALL_SKILLS
+        ? roles
+        : roles.filter((role) => role.skillCategories.includes(activeSkill)),
+    [roles, activeSkill]
+  );
+
+  if (state === "loading") {
+    return (
+      <div className="space-y-4" aria-busy="true" aria-live="polite">
+        <span className="sr-only">Loading open roles</span>
+        {Array.from({ length: 3 }).map((_, index) => (
+          <div
+            key={index}
+            className={`h-40 animate-pulse motion-reduce:animate-none ${tokens.skeleton}`}
+          />
+        ))}
+      </div>
+    );
+  }
+
+  if (state === "error") {
+    return (
+      <div className={tokens.notice}>
+        <p>
+          We couldn&rsquo;t load open roles just now. Try again, or{" "}
+          <a href={VOLUNTEER_FORM_URL} className={`${tokens.link} ${tokens.focus}`}>
+            apply to volunteer
+          </a>{" "}
+          and we&rsquo;ll match you to a role.
+        </p>
+        <button
+          type="button"
+          onClick={load}
+          className={`mt-4 ${tokens.applyProject} ${tokens.focus}`}
+        >
+          Try again
+        </button>
+      </div>
+    );
+  }
+
+  if (roles.length === 0) {
+    return (
+      <p className={tokens.notice}>
+        No roles are open right now.{" "}
+        <a href={VOLUNTEER_FORM_URL} className={`${tokens.link} ${tokens.focus}`}>
+          Apply anyway
+        </a>{" "}
+        and we&rsquo;ll get in touch when one opens up.
+      </p>
+    );
+  }
+
+  const hiddenFilterCount = Math.max(skillFilters.length - MAX_VISIBLE_FILTERS, 0);
+  const visibleFilters =
+    showAllFilters || hiddenFilterCount === 0
+      ? skillFilters
+      : skillFilters.filter(
+          // Keep the active filter on screen even when it lives in the tail.
+          (filter, index) => index < MAX_VISIBLE_FILTERS || filter.name === activeSkill
+        );
+
+  return (
+    <div>
+      {skillFilters.length > 1 && (
+        <div className="mb-6 flex flex-wrap gap-2">
+          <button
+            type="button"
+            onClick={() => setActiveSkill(ALL_SKILLS)}
+            aria-pressed={activeSkill === ALL_SKILLS}
+            className={`${tokens.chip} ${
+              activeSkill === ALL_SKILLS ? tokens.chipActive : tokens.chipIdle
+            } ${tokens.focus}`}
+          >
+            All roles
+            <span className="ml-1.5 opacity-70">{roles.length}</span>
+          </button>
+
+          {visibleFilters.map((filter) => {
+            const isActive = filter.name === activeSkill;
+            return (
+              <button
+                key={filter.name}
+                type="button"
+                onClick={() => setActiveSkill(filter.name)}
+                aria-pressed={isActive}
+                className={`${tokens.chip} ${isActive ? tokens.chipActive : tokens.chipIdle} ${
+                  tokens.focus
+                }`}
+              >
+                {filter.name}
+                <span className="ml-1.5 opacity-70">{filter.count}</span>
+              </button>
+            );
+          })}
+
+          {hiddenFilterCount > 0 && (
+            <button
+              type="button"
+              onClick={() => setShowAllFilters((value) => !value)}
+              className={`${tokens.chip} ${tokens.chipIdle} ${tokens.focus}`}
+            >
+              {showAllFilters ? "Show fewer skills" : `${hiddenFilterCount} more skills`}
+            </button>
+          )}
+        </div>
+      )}
+
+      <p className={`mb-6 ${tokens.count}`} aria-live="polite">
+        {visibleRoles.length === 1 ? "1 open role" : `${visibleRoles.length} open roles`}
+        {activeSkill !== ALL_SKILLS && ` in ${activeSkill}`}
+      </p>
+
+      <div className="space-y-4">
+        {visibleRoles.map((role) => (
+          <OpenRoleCard key={role.id} role={role} tokens={tokens} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/volunteer/openRoleData.ts
+++ b/src/components/volunteer/openRoleData.ts
@@ -1,0 +1,108 @@
+/**
+ * Shape and normalization helpers for open volunteer roles coming from the
+ * T4P Hub (`/api/public/open-roles`, proxied through `/api/open-roles`).
+ *
+ * The upstream payload is nested (`project.name` / `team.name`) and carries
+ * fields the website has no use for. Normalizing at the boundary keeps the UI
+ * free of optional-chaining noise and means a shape change upstream fails in
+ * one place.
+ */
+
+/** How a role is staffed, which decides where its apply button points. */
+export type OpenRoleType = "project" | "team";
+
+export interface OpenRole {
+  id: string;
+  title: string;
+  description: string;
+  /** Name of the coalition project or T4P team the role sits in. */
+  orgName: string;
+  type: OpenRoleType;
+  skillCategories: string[];
+  areasOfInterest: string[];
+  /** Free text, e.g. "5 hours a week". Absent on most roles. */
+  timeCommitment: string;
+  createdAt: string;
+}
+
+export const VOLUNTEER_FORM_URL = "https://techforpalestine.org/volunteer-form";
+export const MEMBERSHIP_URL = "/membership";
+
+/** Upstream descriptions are free text; cap them so one bad row can't bloat the page. */
+const MAX_DESCRIPTION_LENGTH = 4000;
+
+function toTrimmedString(value: unknown, maxLength = 500): string {
+  return typeof value === "string" ? value.trim().slice(0, maxLength) : "";
+}
+
+function toStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.map((entry) => toTrimmedString(entry, 120)).filter(Boolean);
+}
+
+function toOrgName(raw: Record<string, unknown>): string {
+  const nested = (key: "project" | "team") => {
+    const container = raw[key];
+    if (!container || typeof container !== "object") return "";
+    return toTrimmedString((container as Record<string, unknown>).name, 200);
+  };
+  return nested("project") || nested("team");
+}
+
+/**
+ * Converts one upstream row into an `OpenRole`, or returns null when the row
+ * lacks the fields the UI needs to render anything meaningful.
+ */
+export function normalizeOpenRole(raw: unknown): OpenRole | null {
+  if (!raw || typeof raw !== "object") return null;
+  const row = raw as Record<string, unknown>;
+
+  const id = toTrimmedString(row.id, 100);
+  const title = toTrimmedString(row.title, 200);
+  if (!id || !title) return null;
+
+  return {
+    id,
+    title,
+    description: toTrimmedString(row.description, MAX_DESCRIPTION_LENGTH),
+    orgName: toOrgName(row),
+    type: row.type === "team" ? "team" : "project",
+    skillCategories: toStringArray(row.skillCategories),
+    areasOfInterest: toStringArray(row.areasOfInterest),
+    timeCommitment: toTrimmedString(row.timeCommitment, 120),
+    createdAt: toTrimmedString(row.createdAt, 40),
+  };
+}
+
+export function normalizeOpenRoles(raw: unknown): OpenRole[] {
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .map(normalizeOpenRole)
+    .filter((role): role is OpenRole => role !== null)
+    .sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+}
+
+/** Where a role's apply button points, per how the role is staffed. */
+export function getApplyTarget(role: OpenRole): { href: string; label: string } {
+  return role.type === "team"
+    ? { href: MEMBERSHIP_URL, label: "Become a member" }
+    : { href: VOLUNTEER_FORM_URL, label: "Apply to volunteer" };
+}
+
+export interface SkillFilter {
+  name: string;
+  count: number;
+}
+
+/** Skill categories present in the given roles, most common first. */
+export function getSkillFilters(roles: OpenRole[]): SkillFilter[] {
+  const counts = new Map<string, number>();
+  for (const role of roles) {
+    for (const skill of role.skillCategories) {
+      counts.set(skill, (counts.get(skill) ?? 0) + 1);
+    }
+  }
+  return [...counts.entries()]
+    .map(([name, count]) => ({ name, count }))
+    .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name));
+}

--- a/src/components/volunteer/openRoleSkins.ts
+++ b/src/components/volunteer/openRoleSkins.ts
@@ -1,0 +1,92 @@
+/**
+ * The open-roles list appears on two pages built in two different visual
+ * systems: `/volunteer` uses `Layout.astro` (indigo/green, white cards, system
+ * font) and `/volunteer-new` uses `HomeLayout.astro` (cream/sand surfaces, rose
+ * brand accent, Fraunces/Outfit via the `ts-*` scale, which is only loaded by
+ * that layout). Rather than give the section a third identity of its own, each
+ * skin borrows the tokens of the page hosting it.
+ */
+export type OpenRolesSkin = "classic" | "brand";
+
+export interface SkinTokens {
+  heading: string;
+  overline: string;
+  intro: string;
+  count: string;
+  chip: string;
+  chipActive: string;
+  chipIdle: string;
+  card: string;
+  org: string;
+  orgMarker: string;
+  title: string;
+  pill: string;
+  body: string;
+  detailLabel: string;
+  disclosure: string;
+  applyProject: string;
+  applyTeam: string;
+  link: string;
+  skeleton: string;
+  notice: string;
+  focus: string;
+}
+
+const CLASSIC: SkinTokens = {
+  heading: "text-3xl font-bold text-gray-800",
+  overline: "",
+  intro: "text-lg text-gray-600",
+  count: "text-sm text-gray-500",
+  chip: "inline-flex min-h-[44px] items-center rounded-full border px-4 text-sm font-medium transition-colors",
+  chipActive: "border-indigo-600 bg-indigo-600 text-white",
+  chipIdle: "border-gray-300 bg-white text-gray-600 hover:border-indigo-400 hover:text-gray-900",
+  card: "rounded-2xl border border-gray-200 bg-white p-6 shadow-sm transition-colors hover:border-indigo-300",
+  org: "text-sm font-semibold text-indigo-600",
+  orgMarker: "rounded-full border border-green-600 px-2 py-0.5 text-xs font-medium text-green-700",
+  title: "text-xl font-bold text-gray-900",
+  pill: "inline-flex items-center gap-1.5 rounded-full bg-gray-100 px-3 py-1 text-xs font-medium text-gray-600",
+  body: "text-base leading-relaxed text-gray-600",
+  detailLabel: "text-sm font-semibold text-gray-700",
+  disclosure:
+    "inline-flex min-h-[44px] items-center gap-1.5 text-sm font-semibold text-indigo-600 hover:underline",
+  applyProject:
+    "inline-flex min-h-[44px] items-center rounded-full bg-indigo-600 px-5 text-sm font-semibold text-white transition hover:bg-indigo-700",
+  applyTeam:
+    "inline-flex min-h-[44px] items-center rounded-full bg-green-600 px-5 text-sm font-semibold text-white transition hover:bg-green-700",
+  link: "font-medium text-indigo-600 hover:underline",
+  skeleton: "rounded-2xl border border-gray-200 bg-gray-50",
+  notice: "rounded-2xl border border-gray-200 bg-white p-6 text-gray-600",
+  focus: "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600",
+};
+
+const BRAND: SkinTokens = {
+  heading: "ts-heading text-ink",
+  overline: "ts-overline text-ink-secondary",
+  intro: "ts-body-large text-ink-secondary",
+  count: "ts-body-small text-ink-secondary",
+  chip: "ts-caption inline-flex min-h-[44px] items-center rounded-pill border px-4 transition-colors",
+  chipActive: "border-brand bg-brand text-white",
+  chipIdle:
+    "border-ink-divider bg-transparent text-ink-secondary hover:border-brand/40 hover:text-ink",
+  card: "rounded-[20px] border border-butter bg-sand p-6 transition-colors hover:border-brand/30 hover:bg-cream min-[810px]:p-8",
+  org: "ts-body-small font-medium text-brand",
+  orgMarker: "ts-caption rounded-pill border border-ink-divider px-2 py-0.5 text-ink-secondary",
+  title: "ts-quote text-ink",
+  pill: "ts-caption inline-flex items-center gap-1.5 rounded-pill border border-ink-divider px-3 py-1 text-ink-secondary",
+  body: "ts-body leading-relaxed text-ink-secondary",
+  detailLabel: "ts-body-small font-medium text-ink",
+  disclosure:
+    "ts-body-small inline-flex min-h-[44px] items-center gap-1.5 text-brand hover:underline",
+  applyProject:
+    "ts-label inline-flex min-h-[44px] items-center rounded-pill border border-transparent bg-brand px-5 text-white transition-all duration-150 hover:bg-brand-hover active:scale-[0.98]",
+  applyTeam:
+    "ts-label inline-flex min-h-[44px] items-center rounded-pill border border-ink bg-transparent px-5 text-ink transition-all duration-150 hover:bg-ink/5 active:scale-[0.98]",
+  link: "font-medium text-brand hover:underline",
+  skeleton: "rounded-[20px] border border-butter bg-sand",
+  notice: "ts-body rounded-[20px] border border-butter bg-sand p-6 text-ink-secondary",
+  focus: "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand",
+};
+
+export function getSkinTokens(skin: OpenRolesSkin): SkinTokens {
+  return skin === "brand" ? BRAND : CLASSIC;
+}

--- a/src/pages/api/open-roles.ts
+++ b/src/pages/api/open-roles.ts
@@ -1,0 +1,88 @@
+import type { APIRoute } from "astro";
+import * as Sentry from "@sentry/astro";
+import { reportError } from "../../lib/report-error";
+import { normalizeOpenRoles } from "../../components/volunteer/openRoleData";
+
+export const prerender = false;
+
+const HUB_OPEN_ROLES_URL = "https://hub.techforpalestine.org/api/public/open-roles";
+
+/** Upstream can cold-start; one retry on a 5xx covers it without stalling the page. */
+const MAX_RETRIES = 1;
+const RETRY_DELAY_MS = 500;
+
+async function fetchOpenRoles(): Promise<Response> {
+  let lastError: Error | null = null;
+
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      const response = await fetch(HUB_OPEN_ROLES_URL, {
+        method: "GET",
+        headers: {
+          Accept: "application/json",
+          "User-Agent": "T4P-Website/1.0",
+        },
+      });
+
+      // 4xx is a real answer — retrying won't change it.
+      if (response.ok || (response.status >= 400 && response.status < 500)) {
+        return response;
+      }
+      lastError = new Error(`Hub API returned ${response.status}`);
+    } catch (error) {
+      lastError = error instanceof Error ? error : new Error(String(error));
+    }
+
+    if (attempt < MAX_RETRIES) {
+      await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS));
+    }
+  }
+
+  throw lastError ?? new Error("Failed to reach Hub API");
+}
+
+export const GET: APIRoute = async ({ locals }) => {
+  const ctx = locals.runtime?.ctx;
+
+  try {
+    const response = await fetchOpenRoles();
+    if (!response.ok) {
+      throw new Error(`Hub API returned ${response.status}: ${response.statusText}`);
+    }
+
+    const payload = await response.json();
+    // Tolerate both a bare array and a wrapped envelope.
+    const rows = Array.isArray(payload)
+      ? payload
+      : Array.isArray(payload?.data)
+        ? payload.data
+        : Array.isArray(payload?.roles)
+          ? payload.roles
+          : [];
+
+    const roles = normalizeOpenRoles(rows);
+
+    return new Response(JSON.stringify({ roles }), {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+        // Read-only endpoint over public data.
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "GET",
+        "Cache-Control": "no-store",
+      },
+    });
+  } catch (error) {
+    reportError(error, { context: "open-roles" });
+    ctx?.waitUntil(Promise.resolve(Sentry.flush(2000)));
+
+    return new Response(JSON.stringify({ error: "Failed to fetch open roles" }), {
+      status: 502,
+      headers: {
+        "Content-Type": "application/json",
+        "Access-Control-Allow-Origin": "*",
+        "Cache-Control": "no-store",
+      },
+    });
+  }
+};

--- a/src/pages/volunteer-new.astro
+++ b/src/pages/volunteer-new.astro
@@ -4,6 +4,7 @@ import HomeLayout from "../layouts/HomeLayout.astro";
 import HomeNavbar from "../components/home/HomeNavbar.astro";
 import Button from "../components/ui/Button.astro";
 import SignUpForm from "../structures/SignUpForm.astro";
+import OpenRoles from "../components/volunteer/OpenRoles.tsx";
 
 const membershipLive = getEnv("MEMBERSHIP_LIVE", Astro.locals) === "true";
 ---
@@ -36,14 +37,27 @@ const membershipLive = getEnv("MEMBERSHIP_LIVE", Astro.locals) === "true";
             >
               Apply to Volunteer Now
             </Button>
-            <Button
-              href="https://techforpalestine.notion.site/75a9979ec7de4a7db123e54e56546f27?v=d641a2a6722047efbc18a323ece981d0&pvs=74"
-              variant="ghost"
-              size="md"
-            >
-              Current Volunteer Needs
-            </Button>
           </div>
+        </div>
+        <div class="mt-10 h-px w-full bg-ink-divider min-[810px]:mt-14"></div>
+      </div>
+    </section>
+
+    <!-- Open Roles -->
+    <section
+      id="open-roles"
+      class="scroll-mt-24 bg-page px-6 pb-14 pt-4 min-[810px]:px-10 min-[810px]:pb-20"
+    >
+      <div class="mx-auto max-w-[1400px]">
+        <div class="volunteer-animate max-w-[900px]">
+          <p class="ts-overline mb-6 text-ink-secondary">Open roles</p>
+          <h2 class="ts-heading mb-6 text-ink">Current volunteer needs</h2>
+          <p class="ts-body-large mb-10 max-w-[65ch] text-ink-secondary">
+            Roles open right now across coalition projects and Tech for Palestine teams. Project
+            roles go through our volunteer application; T4P team roles are filled through
+            membership.
+          </p>
+          <OpenRoles skin="brand" client:only="react" />
         </div>
       </div>
     </section>
@@ -162,9 +176,7 @@ const membershipLive = getEnv("MEMBERSHIP_LIVE", Astro.locals) === "true";
             to get matched with the right project or team—even if you're not sure how you want to contribute!{
               " "
             }
-            <a
-              href="https://techforpalestine.notion.site/75a9979ec7de4a7db123e54e56546f27?v=d641a2a6722047efbc18a323ece981d0&pvs=74"
-              class="font-medium text-brand underline hover:text-brand-hover"
+            <a href="#open-roles" class="font-medium text-brand underline hover:text-brand-hover"
               >Check out specific roles we're looking for right now!</a
             >
           </p>
@@ -345,13 +357,6 @@ const membershipLive = getEnv("MEMBERSHIP_LIVE", Astro.locals) === "true";
               arrow
             >
               Apply to Volunteer Now
-            </Button>
-            <Button
-              href="https://techforpalestine.notion.site/75a9979ec7de4a7db123e54e56546f27?v=d641a2a6722047efbc18a323ece981d0&pvs=74"
-              variant="ghost"
-              size="md"
-            >
-              Current Volunteer Needs
             </Button>
           </div>
         </div>

--- a/src/pages/volunteer.astro
+++ b/src/pages/volunteer.astro
@@ -1,5 +1,6 @@
 ---
 import Socials from "../components/Socials.astro";
+import OpenRoles from "../components/volunteer/OpenRoles.tsx";
 import Layout from "../layouts/Layout.astro";
 import "../styles/base.css";
 ---
@@ -20,19 +21,25 @@ import "../styles/base.css";
 
     <!-- New Buttons Section -->
     <section class="mx-auto max-w-4xl px-6">
-      <div class="flex justify-center space-x-4">
+      <div class="flex justify-center">
         <a
           href="https://techforpalestine.org/volunteer-form"
           class="inline-flex items-center rounded-full bg-indigo-600 px-8 py-4 text-lg font-semibold text-white shadow-md transition hover:bg-indigo-700"
         >
           Apply to Volunteer Now
         </a>
-        <a
-          href="https://techforpalestine.notion.site/75a9979ec7de4a7db123e54e56546f27?v=d641a2a6722047efbc18a323ece981d0&pvs=74"
-          class="inline-flex items-center rounded-full bg-green-600 px-8 py-4 text-lg font-semibold text-white shadow-md transition hover:bg-green-700"
-        >
-          Current Volunteer Needs
-        </a>
+      </div>
+    </section>
+
+    <!-- Open Roles -->
+    <section id="open-roles" class="mx-auto max-w-5xl scroll-mt-24 px-6">
+      <h2 class="text-3xl font-bold text-gray-800">Current volunteer needs</h2>
+      <p class="mt-3 max-w-[70ch] text-lg text-gray-600">
+        Roles open right now across coalition projects and Tech for Palestine teams. Project roles
+        go through our volunteer application; T4P team roles are filled through membership.
+      </p>
+      <div class="mt-8">
+        <OpenRoles client:only="react" />
       </div>
     </section>
 
@@ -106,10 +113,7 @@ import "../styles/base.css";
                 href="https://techforpalestine.org/volunteer-form"
                 class="font-medium text-indigo-600 hover:underline">volunteer application form</a
               > to get matched with the right project or team—even if you're not sure how you want to
-              contribute! <a
-                href="https://techforpalestine.notion.site/75a9979ec7de4a7db123e54e56546f27?v=d641a2a6722047efbc18a323ece981d0&pvs=74"
-                class="text-indigo-600 hover:underline"
-              >
+              contribute! <a href="#open-roles" class="text-indigo-600 hover:underline">
                 (Check out specific roles we're looking for right now!)</a
               >
             </p>
@@ -171,18 +175,12 @@ import "../styles/base.css";
         </p>
       </div>
 
-      <div class="mt-8 flex justify-center space-x-4">
+      <div class="mt-8 flex justify-center">
         <a
           href="https://techforpalestine.org/volunteer-form"
           class="inline-flex items-center rounded-full bg-indigo-600 px-8 py-4 text-lg font-semibold text-white shadow-md transition hover:bg-indigo-700"
         >
           Apply to Volunteer Now
-        </a>
-        <a
-          href="https://techforpalestine.notion.site/75a9979ec7de4a7db123e54e56546f27?v=d641a2a6722047efbc18a323ece981d0&pvs=74"
-          class="inline-flex items-center rounded-full bg-green-600 px-8 py-4 text-lg font-semibold text-white shadow-md transition hover:bg-green-700"
-        >
-          Current Volunteer Needs
         </a>
       </div>
     </section>


### PR DESCRIPTION
## What

The **Current Volunteer Needs** button on `/volunteer` and `/volunteer-new` pointed at a Notion board. This replaces it with a filterable list of the live open roles from the Hub's public API (`hub.techforpalestine.org/api/public/open-roles` — 20 roles at time of writing).

## How

**`/api/open-roles`** — server proxy following the `/api/projects` pattern. One retry on 5xx for cold starts (4xx returns immediately), tolerates a bare array or a `{data}`/`{roles}` envelope, `no-store`, `ACAO: *` (read-only GET over public data). Client gets a generic `{ error }`; details go to `console.error` + Sentry via `reportError`. No secret needed — the upstream endpoint is public.

**`openRoleData.ts`** — normalizes upstream rows at the boundary: flattens `project.name`/`team.name` into a single `orgName`, coerces and length-caps every string, drops rows missing `id`/`title`, sorts newest-first. A shape change upstream now fails in one place.

**`OpenRoles.tsx` / `OpenRoleCard.tsx`** — client island (`client:only="react"`), fetched from `/api/open-roles` so a Hub outage never blocks the page render.

## Design notes

- **Single-column bands, not a card grid.** Expanding a long description in a grid reflows its siblings; a stacked list just pushes content down, and it gives the descriptions a sane reading measure.
- **Two skins, one structure.** The pages use different design systems — `/volunteer` is `Layout.astro` (indigo/green, white cards, system font) and `/volunteer-new` is `HomeLayout.astro` (cream/sand/butter + rose `#AB4956`, Fraunces/Outfit via the `ts-*` scale, which only that layout loads). The island takes a `skin` prop that maps to the host page's tokens rather than introducing a third identity.
- **Surfaces on `/volunteer-new`** follow `projects-new.astro`: the section sits on `bg-page` with an `h-px bg-ink-divider` rule closing the hero. Putting it on `bg-sand` broke the page's page/sand alternation for every section below it *and* put sand cards on a sand ground.
- **Collapsed previews flatten whitespace**, expanded text keeps `whitespace-pre-line`. Several descriptions open with a short heading line that would otherwise spend the whole three-line clamp.
- **Apply target follows how the role is staffed:** `type === "team"` → `/membership` ("Become a member", matching that page's own title); otherwise the volunteer form ("Apply to volunteer", matching the existing CTA). The label carries the distinction, not just colour, and team roles also get a bordered "T4P team" marker.
- **Filters cap at the 8 most common skills** with the tail behind a toggle — 15 categories with labels like "Graphic Design / Illustration", 9 of them holding a single role, would have outweighed the list itself. The active filter stays visible even when it's in the tail.
- Motion is limited to the disclosure chevron; hover is a border/background shift, matching `ProjectCard`. Skeletons carry `motion-reduce:animate-none`.
- A11y: chips are `aria-pressed` buttons, the disclosure is `aria-expanded`/`aria-controls`, the result count is an `aria-live="polite"` region, targets are ≥44px, and each apply link carries an `sr-only` role name so 20 otherwise-identical links read distinctly.

## Also in this change

The in-prose "Check out specific roles we're looking for right now!" link on both pages is repointed at `#open-roles`. Left alone, it would have kept the replaced Notion board linked from the page.

## Known upstream quirks (not worked around)

- `project.id` is `null` on every row, so cards can't deep-link to a project page.
- One title reads `Fact Checke`; rendered as-is rather than patched client-side.

## Test plan

- [ ] `/volunteer` — roles load, styling matches the page's indigo/white system, filters and Read-the-full-role work
- [ ] `/volunteer-new` — roles load, styling matches the cream/rose system, hero divider reads correctly and section surfaces still alternate below
- [ ] Team roles (currently *Web Developer* — Exposing Israel Bonds, *Outreach helper* — Internships for students from Gaza) show the "T4P team" marker and link to `/membership`; project roles link to the volunteer form
- [ ] "Check out specific roles" link scrolls to the list on both pages
- [ ] Error state: block `/api/open-roles` in devtools and confirm the notice + working **Try again**
- [ ] Keyboard-only pass over chips, disclosures, and apply links; check focus rings are visible